### PR TITLE
Consolidate InitializeResult with InterpreterResult

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -270,23 +270,23 @@ pub fn no_traps(wasm: &[u8]) {
     };
 
     match state.initialize_module(module_box, &text, 10000) {
-        InitializeResult::Ok => {}
-        InitializeResult::OutOfFuel => {
+        InterpreterResult::Finished => {}
+        InterpreterResult::OutOfFuel => {
             log::debug!("start routine out of fuel");
             return;
         }
-        InitializeResult::Trap(TrapReason::StackOverflow) => {
+        InterpreterResult::Trap(TrapReason::StackOverflow) => {
             // Wasm Smith cannot avoid this. Also this is not a bug so it's ok to drop this run
             log::debug!("module hit a stack overflow during initialization");
             return;
         }
-        InitializeResult::Trap(trap_reason) => {
+        InterpreterResult::Trap(trap_reason) => {
             panic!("Trap during initialization: {trap_reason:?}")
         }
-        InitializeResult::ReaderError(ir_reader_error) => {
+        InterpreterResult::ReaderError(ir_reader_error) => {
             panic!("Ir Reader Error: {ir_reader_error:?}")
         }
-        InitializeResult::Pause => panic!("Host init pause"),
+        InterpreterResult::Pause => panic!("Host init pause"),
     }
 
     log::debug!("module instantiated");

--- a/crates/spacewasm_std/benches/coremark.rs
+++ b/crates/spacewasm_std/benches/coremark.rs
@@ -1,7 +1,6 @@
 use spacewasm::{
-    CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostModule, InitializeResult,
-    InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, RawValue, Ref, Store, Value,
-    WasmRef,
+    CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostModule, InterpreterResult,
+    InterpreterRunner, ModuleRef, PageAllocator, RawValue, Ref, Store, Value, WasmRef,
 };
 use spacewasm_util::{FileStream, RustSystemAllocator};
 use std::ops::ControlFlow;
@@ -77,11 +76,11 @@ fn main() {
 
     let mut state = store.allocate(1024).unwrap();
     match state.initialize_module(spacewasm::Box::new(module).unwrap(), &text, usize::MAX) {
-        InitializeResult::Ok => {}
-        InitializeResult::OutOfFuel => panic!("insufficient fuel for initialization"),
-        InitializeResult::Trap(t) => panic!("trap during initialization {t:?}"),
-        InitializeResult::ReaderError(e) => panic!("ir reader error {e:?}"),
-        InitializeResult::Pause => panic!("pause during init"),
+        InterpreterResult::Finished => {}
+        InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
+        InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
+        InterpreterResult::ReaderError(e) => panic!("ir reader error {e:?}"),
+        InterpreterResult::Pause => panic!("pause during init"),
     }
 
     let module = state.store.modules().last().unwrap();

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -1,7 +1,7 @@
 use spacewasm::{
-    vec, Box, CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostFunctionBreak,
-    HostModule, InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref, SectionKind,
-    ValType, Value, WasmRef,
+    Box, CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostFunctionBreak, HostModule,
+    InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref, SectionKind, ValType,
+    Value, WasmRef, vec,
 };
 use spacewasm_util::{FileStream, RustSystemAllocator};
 use std::ops::ControlFlow;

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -1,7 +1,7 @@
 use spacewasm::{
-    Box, CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostFunctionBreak, HostModule,
-    InitializeResult, InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref,
-    SectionKind, ValType, Value, WasmRef, vec,
+    vec, Box, CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostFunctionBreak,
+    HostModule, InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref, SectionKind,
+    ValType, Value, WasmRef,
 };
 use spacewasm_util::{FileStream, RustSystemAllocator};
 use std::ops::ControlFlow;
@@ -139,11 +139,11 @@ fn main() {
 
     let mut state = store.allocate(1024).unwrap();
     match state.initialize_module(Box::new(module).unwrap(), &text, usize::MAX) {
-        InitializeResult::Ok => {}
-        InitializeResult::OutOfFuel => panic!("insufficient fuel for initialization"),
-        InitializeResult::Trap(t) => panic!("trap during initialization {t:?}"),
-        InitializeResult::ReaderError(e) => panic!("ir reader error {e:?}"),
-        InitializeResult::Pause => panic!("pause during init"),
+        InterpreterResult::Finished => {}
+        InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
+        InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
+        InterpreterResult::ReaderError(e) => panic!("ir reader error {e:?}"),
+        InterpreterResult::Pause => panic!("pause during init"),
     }
 
     let module = state.store.modules().last().unwrap();

--- a/crates/spacewasm_util/src/bin/spacewasm-trace.rs
+++ b/crates/spacewasm_util/src/bin/spacewasm-trace.rs
@@ -12,7 +12,7 @@ use spacewasm::{
     InterpreterResult, InterpreterRunner, MemoryStatistics, Module, ModuleRef, ReaderError, Ref,
     Store, WasmMemoryAllocator, WasmRef, WasmStream,
 };
-use spacewasm::{InitializeResult, ValType, Value};
+use spacewasm::{ValType, Value};
 use spacewasm_util::StateTracer;
 use std::env;
 use std::fs;
@@ -238,20 +238,20 @@ fn main() {
     };
 
     match init_result {
-        InitializeResult::Ok => {}
-        InitializeResult::OutOfFuel => {
+        InterpreterResult::Finished => {}
+        InterpreterResult::OutOfFuel => {
             eprintln!("Module initialization ran out of fuel (instruction limit)");
             process::exit(1);
         }
-        InitializeResult::Trap(trap_reason) => {
+        InterpreterResult::Trap(trap_reason) => {
             eprintln!("Trap during initialization: {trap_reason:?}");
             process::exit(1);
         }
-        InitializeResult::ReaderError(ir_reader_error) => {
+        InterpreterResult::ReaderError(ir_reader_error) => {
             eprintln!("Reader error during initialization: {ir_reader_error:?}");
             process::exit(1);
         }
-        InitializeResult::Pause => {
+        InterpreterResult::Pause => {
             eprintln!("Module initialization paused");
             process::exit(1);
         }

--- a/src/interpreter_tests.rs
+++ b/src/interpreter_tests.rs
@@ -3,7 +3,7 @@
 #[allow(clippy::excessive_precision)]
 mod tests {
     use crate::{
-        AllocError, BaseVisitor, InitializeResult, Interpreter, InterpreterState, IrVisitor,
+        AllocError, BaseVisitor, Interpreter, InterpreterResult, InterpreterState, IrVisitor,
         MemArg, MemType, Memory, MemoryKind, Module, ModuleRef, Store, ValType,
     };
 
@@ -72,11 +72,11 @@ mod tests {
 
         let mut state = store.allocate(1024).unwrap();
         match state.initialize_module(crate::Box::new(module).unwrap(), &[], usize::MAX) {
-            InitializeResult::Ok => {}
-            InitializeResult::OutOfFuel => panic!("insufficient fuel for initialization"),
-            InitializeResult::Trap(t) => panic!("trap during initialization {t:?}"),
-            InitializeResult::ReaderError(e) => panic!("ir reader error {e:?}"),
-            InitializeResult::Pause => panic!("pause during init"),
+            InterpreterResult::Finished => {}
+            InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
+            InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
+            InterpreterResult::ReaderError(e) => panic!("ir reader error {e:?}"),
+            InterpreterResult::Pause => panic!("pause during init"),
         }
 
         state.memory = state.store.get_memory(ModuleRef(0)).clone();

--- a/src/store.rs
+++ b/src/store.rs
@@ -140,15 +140,6 @@ impl Store {
     }
 }
 
-#[derive(Debug)]
-pub enum InitializeResult {
-    Ok,
-    OutOfFuel,
-    Trap(TrapReason),
-    ReaderError(IrReaderError),
-    Pause,
-}
-
 impl<'store> InterpreterState<'store> {
     pub fn clear_memory(&mut self) {
         self.memory = self.store.zero_memory.clone();
@@ -163,7 +154,7 @@ impl<'store> InterpreterState<'store> {
         module: Box<Module>,
         code: &[Box<TextPage>],
         n_instructions: usize,
-    ) -> InitializeResult {
+    ) -> InterpreterResult {
         let interpreter = Interpreter::default();
         self.store.modules.push(module);
 
@@ -186,12 +177,12 @@ impl<'store> InterpreterState<'store> {
                         [index as usize]
                         .call(self, &[])
                     {
-                        HostFunctionResult::Continue(_) => InitializeResult::Ok,
+                        HostFunctionResult::Continue(_) => InterpreterResult::Finished,
                         HostFunctionResult::Break(HostFunctionBreak::Trap) => {
-                            InitializeResult::Trap(TrapReason::Host)
+                            InterpreterResult::Trap(TrapReason::Host)
                         }
                         HostFunctionResult::Break(HostFunctionBreak::Pause) => {
-                            InitializeResult::Pause
+                            InterpreterResult::Pause
                         }
                     };
                 }
@@ -200,16 +191,10 @@ impl<'store> InterpreterState<'store> {
                 }
             }
         } else {
-            return InitializeResult::Ok;
+            return InterpreterResult::Finished;
         }
 
         // Spin the interpreter
-        match interpreter.run(code, self, n_instructions) {
-            InterpreterResult::OutOfFuel => InitializeResult::OutOfFuel,
-            InterpreterResult::Finished => InitializeResult::Ok,
-            InterpreterResult::Trap(t) => InitializeResult::Trap(t),
-            InterpreterResult::Pause => InitializeResult::Pause,
-            InterpreterResult::ReaderError(r) => InitializeResult::ReaderError(r),
-        }
+        interpreter.run(code, self, n_instructions)
     }
 }

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -1,12 +1,12 @@
 use super::inspector::{Inspector, LimitedVec};
 use serde::{Deserialize, Serialize};
 use spacewasm::{
-    global_allocator, vec, AllocError, Allocator, CodeBuilder, CompilerOptions,
-    ConstantExprError, ExportDesc, GlobalValue, GlobalValueError, HostFunction, HostGlobal, HostModule,
-    InnerVec, Interpreter, InterpreterResult, InterpreterRunner, InterpreterState, Limit,
-    Memory, MemoryError, MemoryStatistics, Module, ModuleRef, ParseError, ReaderError, Ref, Stack,
-    Store, TrapReason, ValType, ValidationError, Value, WasmMemoryAllocator, WasmRef,
-    WasmStream,
+    AllocError, Allocator, CodeBuilder, CompilerOptions, ConstantExprError, ExportDesc,
+    GlobalValue, GlobalValueError, HostFunction, HostGlobal, HostModule, InnerVec, Interpreter,
+    InterpreterResult, InterpreterRunner, InterpreterState, Limit, Memory, MemoryError,
+    MemoryStatistics, Module, ModuleRef, ParseError, ReaderError, Ref, Stack, Store, TrapReason,
+    ValType, ValidationError, Value, WasmMemoryAllocator, WasmRef, WasmStream, global_allocator,
+    vec,
 };
 use std::alloc::Layout;
 use std::cell::RefCell;

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -1,12 +1,12 @@
 use super::inspector::{Inspector, LimitedVec};
 use serde::{Deserialize, Serialize};
 use spacewasm::{
-    AllocError, Allocator, CodeBuilder, CompilerOptions, ConstantExprError, ExportDesc,
-    GlobalValue, GlobalValueError, HostFunction, HostGlobal, HostModule, InitializeResult,
-    InnerVec, Interpreter, InterpreterResult, InterpreterRunner, InterpreterState, Limit, Memory,
-    MemoryError, MemoryStatistics, Module, ModuleRef, ParseError, ReaderError, Ref, Stack, Store,
-    TrapReason, ValType, ValidationError, Value, WasmMemoryAllocator, WasmRef, WasmStream,
-    global_allocator, vec,
+    global_allocator, vec, AllocError, Allocator, CodeBuilder, CompilerOptions,
+    ConstantExprError, ExportDesc, GlobalValue, GlobalValueError, HostFunction, HostGlobal, HostModule,
+    InnerVec, Interpreter, InterpreterResult, InterpreterRunner, InterpreterState, Limit,
+    Memory, MemoryError, MemoryStatistics, Module, ModuleRef, ParseError, ReaderError, Ref, Stack,
+    Store, TrapReason, ValType, ValidationError, Value, WasmMemoryAllocator, WasmRef,
+    WasmStream,
 };
 use std::alloc::Layout;
 use std::cell::RefCell;
@@ -449,7 +449,7 @@ fn compare_values(actual: Value, expected: &ValueSpec) {
 enum ModuleLoadError {
     DecodeError(ParseError),
     AllocationError(MemoryError),
-    InitializeError(InitializeResult),
+    InitializeError(InterpreterResult),
 }
 
 impl From<ParseError> for ModuleLoadError {
@@ -572,7 +572,7 @@ fn load_module(
     // Initialize the module
     ctx.with_state(|state| {
         match state.initialize_module(spacewasm::Box::new(module).unwrap(), &text, usize::MAX) {
-            InitializeResult::Ok => Ok(()),
+            InterpreterResult::Finished => Ok(()),
             result => Err(ModuleLoadError::InitializeError(result)),
         }
     })
@@ -817,9 +817,9 @@ fn check_decode_error(err: ParseError, text: String) {
     }
 }
 
-fn check_initialization_error(result: InitializeResult, text: &str) {
+fn check_initialization_error(result: InterpreterResult, text: &str) {
     match (result, text) {
-        (InitializeResult::Trap(TrapReason::Unreachable), "unreachable") => {}
+        (InterpreterResult::Trap(TrapReason::Unreachable), "unreachable") => {}
         (result, text) => {
             panic!("Could not match initialization error text '{text}' with result {result:?}")
         }


### PR DESCRIPTION
With #13, `InitializeResult` and `InterpreterResult` were essentially identical. This consolidates them into a single enum.