### PR TITLE
Refactor br.table to not incur stack allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ resource-constrained spacecraft environments:
 - **Value stack**: Configurable via generic parameter `MAX_STACK_DEPTH`, values per function
 - **Label jumps**: 22-bit signed offset (±2,097,151 instructions)
 - **Stack truncation depth**: Maximum 255 32-bit words per label jump
-- **br_table cases**: Maximum 256 branch targets
 
 ### Instruction Encoding
 

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -191,7 +191,7 @@ fn main() {
     for i in &module.exports {
         match &i.desc {
             ExportDesc::Func(fi) => {
-                eprintln!("Function: {} {:?}", &i.name, fi);
+                eprintln!("Function: {} {:?}", i.name, fi);
             }
             ExportDesc::Table(_) => {}
             ExportDesc::Mem(_) => {}

--- a/crates/spacewasm_util/src/debug.rs
+++ b/crates/spacewasm_util/src/debug.rs
@@ -232,7 +232,9 @@ impl<'a, ST: OutputStream, S, E, T: BaseVisitor<State = S, Error = E> + WasmVisi
     visit_fn!(else_);
     visit_fn!(br, l: LabelIdx);
     visit_fn!(br_if, l: LabelIdx);
-    visit_fn!(br_table, lut: &[LabelIdx], default_: LabelIdx);
+    visit_fn!(br_table_start, len: u32);
+    visit_fn!(br_table_branch, br: LabelIdx);
+    visit_fn!(br_table_finish, default_: LabelIdx);
 
     visit_fn!(return_);
     visit_fn!(call, x: FuncIdx);

--- a/src/code.rs
+++ b/src/code.rs
@@ -209,16 +209,14 @@ impl<'wasm> Reader<'wasm> {
                 BR => instruction!(br, LabelIdx),
                 BR_IF => instruction!(br_if, LabelIdx),
                 BR_TABLE => {
-                    // FIXME(tumbar) Is it possible to use an iterator and not require up-front allocation?
-                    let lut = self
-                        .read_vec_stack::<24700, LabelIdx>(LabelIdx::read)
-                        .map_err(|e| match e {
-                            ValidationError::VecTooLong => ValidationError::BrTableHasTooManyCases,
-                            e => e,
-                        })?;
-
+                    let len = self.read_u32()?;
+                    visitor.br_table_start(len, state)?;
+                    for _ in 0..len {
+                        let br = LabelIdx::read(self)?;
+                        visitor.br_table_branch(br, state)?
+                    }
                     let default_ = LabelIdx::read(self)?;
-                    visitor.br_table(&lut, default_, state)?;
+                    visitor.br_table_finish(default_, state)?;
                 }
                 RETURN => instruction!(return_),
                 CALL => instruction!(call, FuncIdx),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -185,22 +185,25 @@ impl<'a, const MAX_PAGES: usize, const MAX_CONTROL_FRAMES: usize, const MAX_STAC
         Ok(())
     }
 
-    fn br_table(
+    fn br_table_start(&self, len: u32, state: &mut Self::State) -> Result<(), Self::Error> {
+        let _ = state.pop_stack(ValType::I32)?;
+        state.instr_imm_8_or_16(BR_TABLE, len)?;
+        Ok(())
+    }
+
+    fn br_table_branch(&self, br: LabelIdx, state: &mut Self::State) -> Result<(), Self::Error> {
+        let case_return = state.write_label_target(br)?;
+        state.check_br_table_result(case_return)?;
+        Ok(())
+    }
+
+    fn br_table_finish(
         &self,
-        lut: &[LabelIdx],
         default_: LabelIdx,
         state: &mut Self::State,
     ) -> Result<(), Self::Error> {
-        let _ = state.pop_stack(ValType::I32)?;
-        state.instr_imm_8_or_16(BR_TABLE, lut.len() as u32)?;
         let def_result = state.write_label_target(default_)?;
-        for l in lut {
-            let case_return = state.write_label_target(*l)?;
-            if def_result != case_return {
-                return Err(ValidationError::BlockResultTypeMismatch);
-            }
-        }
-
+        state.check_and_clear_br_table_result(def_result)?;
         state.pop_result_type(def_result)?;
         state.mark_unreachable();
         Ok(())

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -275,7 +275,9 @@ impl<'a> WasmVisitor for ConstantCompiler<'a> {
     invalid_constant_fn!(else_);
     invalid_constant_fn!(br, l: LabelIdx);
     invalid_constant_fn!(br_if, l: LabelIdx);
-    invalid_constant_fn!(br_table, lut: &[LabelIdx], default_: LabelIdx);
+    invalid_constant_fn!(br_table_start, len: u32);
+    invalid_constant_fn!(br_table_branch, br: LabelIdx);
+    invalid_constant_fn!(br_table_finish, default_: LabelIdx);
 
     invalid_constant_fn!(return_);
     invalid_constant_fn!(call, x: FuncIdx);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1330,21 +1330,17 @@ impl<'store> IrVisitor for Interpreter<'store> {
         let v = state.stack.read_u32(state.sp);
         let label = cases(v);
 
-        // If the count is greater than 255, an extra word was read. We need to
-        // offset the jump by an additional word if this is the case.
+        // If the count is greater than 255, the br_table was encoded as a 16-bit extended immediate.
+        // We need to offset the jump by an additional word if this is the case.
         let op_offset = if n >= 0xFF { 2 } else { 1 };
 
         if v < n {
             // A standard case, compute the offset from the current PC
-            // Instruction opcode offset  + default case (2 words) + previous cases (each 2 words)
-            self.br_impl(
-                JumpOffset::offset(op_offset + 2 + (2 * v as i32)),
-                label,
-                state,
-            )?;
+            // Instruction opcode offset + previous cases (each 2 words)
+            self.br_impl(JumpOffset::offset(op_offset + (2 * v as i32)), label, state)?;
         } else {
-            // The default case, constant offset
-            self.br_impl(JumpOffset::offset(op_offset), label, state)?;
+            // The default case, all cases together
+            self.br_impl(JumpOffset::offset(op_offset + (2 * n as i32)), label, state)?;
         }
 
         Ok(())

--- a/src/ir_reader.rs
+++ b/src/ir_reader.rs
@@ -139,8 +139,6 @@ impl<'code> IrReader<'code> {
                     imm as u32
                 };
 
-                let default_ = self.read_u32(pc).unwrap();
-
                 visitor.br_table(
                     n,
                     |case_| {
@@ -160,6 +158,9 @@ impl<'code> IrReader<'code> {
                                 }
                             }
 
+                            // Dump the default case
+                            self.read_u32(pc).unwrap();
+
                             lt.into()
                         } else {
                             // Dump all the cases and return the default
@@ -167,7 +168,8 @@ impl<'code> IrReader<'code> {
                                 self.read_u32(pc).unwrap();
                             }
 
-                            default_.into()
+                            let lt = self.read_u32(pc).unwrap();
+                            lt.into()
                         }
                     },
                     state,

--- a/src/text.rs
+++ b/src/text.rs
@@ -412,6 +412,7 @@ pub struct TextBuilder<
     control_frames: StaticVec<ControlFrame, MAX_CONTROL_FRAMES>,
     value_stack: StaticVec<OperandType, MAX_STACK_DEPTH>,
     stack_highwater: usize,
+    br_table_result: Option<ResultType>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -466,6 +467,7 @@ impl<'a, const MAX_PAGES: usize, const MAX_CONTROL_FRAMES: usize, const MAX_STAC
             control_frames: Default::default(),
             value_stack: Default::default(),
             stack_highwater: 0,
+            br_table_result: None,
         };
 
         // Push the implicit function control frame per the spec
@@ -490,6 +492,35 @@ impl<'a, const MAX_PAGES: usize, const MAX_CONTROL_FRAMES: usize, const MAX_STAC
 
     pub fn stack_usage(&self) -> usize {
         self.stack_highwater
+    }
+
+    pub fn check_br_table_result(&mut self, r: ResultType) -> Result<(), ValidationError> {
+        if let Some(other) = self.br_table_result {
+            if other != r {
+                Err(ValidationError::BlockResultTypeMismatch)
+            } else {
+                Ok(())
+            }
+        } else {
+            self.br_table_result = Some(r);
+            Ok(())
+        }
+    }
+
+    pub fn check_and_clear_br_table_result(
+        &mut self,
+        def_result: ResultType,
+    ) -> Result<(), ValidationError> {
+        if let Some(other) = self.br_table_result {
+            if other != def_result {
+                Err(ValidationError::BlockResultTypeMismatch)
+            } else {
+                self.br_table_result = None;
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
     }
 
     /// Compute the offset in 32-bit words of a local variable given its index

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -224,7 +224,9 @@ pub trait WasmVisitor: BaseVisitor {
     visit_fn!(else_);
     visit_fn!(br, l: LabelIdx);
     visit_fn!(br_if, l: LabelIdx);
-    visit_fn!(br_table, lut: &[LabelIdx], default_: LabelIdx);
+    visit_fn!(br_table_start, len: u32);
+    visit_fn!(br_table_branch, br: LabelIdx);
+    visit_fn!(br_table_finish, default_: LabelIdx);
 
     visit_fn!(return_);
     visit_fn!(call, x: FuncIdx);

--- a/tests/util/inspector.rs
+++ b/tests/util/inspector.rs
@@ -252,7 +252,9 @@ impl<'a, S, E, T: BaseVisitor<State = S, Error = E> + WasmVisitor> WasmVisitor
     visit_fn!(else_);
     visit_fn!(br, l: LabelIdx);
     visit_fn!(br_if, l: LabelIdx);
-    visit_fn!(br_table, lut: &[LabelIdx], default_: LabelIdx);
+    visit_fn!(br_table_start, len: u32);
+    visit_fn!(br_table_branch, br: LabelIdx);
+    visit_fn!(br_table_finish, default_: LabelIdx);
 
     visit_fn!(return_);
     visit_fn!(call, x: FuncIdx);


### PR DESCRIPTION
Closes #24

The visitor trait needed to be changed to support this for two reasons:

1. Passing an iterator that mutably borrows `Reader` was a pain and had no utlity
2. The wasm bytecode encodes the default case at the end so the API implied an up-front read

This change also required an IR change to encode the branches in the same order as the wasm bytecode