### PR TITLE
Remove unused TooManyBrTableCases

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -112,7 +112,6 @@ pub enum ValidationError {
     FunctionReturnsTooLarge,
     TooManyLocals,
     InvalidConstInstruction,
-    BrTableHasTooManyCases,
     GlobalTypeMismatch,
     AlignmentLargerThanType,
     InvalidStartFunctionSignature,

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -762,7 +762,6 @@ fn check_decode_error(err: ParseError, text: String) {
         (ValidationError::FunctionResultTypeMismatch, "type mismatch") => {}
         (ValidationError::FunctionIdxOutOfRange, "unknown function") => {}
         (ValidationError::FunctionReturnsTooLarge, "invalid result arity") => {}
-        (ValidationError::BrTableHasTooManyCases, "br.table has too many cases") => {}
         (ValidationError::TableNotDefined, "unknown table") => {}
         (ValidationError::InvalidTableIndex, "malformed value type") => {}
         (ValidationError::InvalidLabelIndex, "unexpected end of section or function") => {}


### PR DESCRIPTION
This is left over from #27. We no longer have a bound on br.table instructions.