### PR TITLE
Pass correct index argument to call_host()

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1518,7 +1518,7 @@ impl<'store> IrVisitor for Interpreter<'store> {
                     return Err(InterpreterBreak::Trap(TrapReason::InvalidTableFunctionType));
                 }
 
-                self.call_host(*module, i as u16, state)
+                self.call_host(*module, *index, state)
             }
             Some(TableElement::Uninitialized) => Err(InterpreterBreak::Trap(
                 TrapReason::UninitializedTableElement,


### PR DESCRIPTION
Previously, `i` was passed into `call_host()` instead of `index`. This fix avoids potentially calling the wrong host function.