### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/nasa/spacewasm/security/code-scanning/6](https://github.com/nasa/spacewasm/security/code-scanning/6)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs default to least privilege.

Best fix here (without changing intended functionality in shown jobs): add

```yml
permissions:
  contents: read
```

near the top level (after `on:` and before `env:` is a clean location). This satisfies CodeQL’s recommendation and is sufficient for the displayed jobs (`actions/checkout`, cargo build/test/lint, cache usage). If any hidden job needs extra scopes, it can define job-level `permissions` later without removing this safe default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
