### PR TITLE
Potential fix for code scanning alert no. 5: Access of invalid pointer

### DIFF
--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -120,16 +120,17 @@ impl<T: ?Sized, A: Allocator> DerefMut for Box<T, A> {
 
 impl<T: ?Sized, A: Allocator> Drop for Box<T, A> {
     fn drop(&mut self) {
-        // Null pointers do not have an allocation, they are usually just for dyn* on ZSTs
-        if !self.ptr.is_null() {
-            unsafe {
-                // SAFETY: Compute the layout before dropping the value.
-                // Creating a reference to get metadata is safe even though we're about to drop.
-                let layout = Layout::for_value(&*self.ptr);
+        unsafe {
+            // SAFETY: Compute the layout before dropping the value.
+            // Creating a reference to get metadata is safe even though we're about to drop.
+            let layout = Layout::for_value(&*self.ptr);
 
-                // Drop the contained value
-                ptr::drop_in_place(self.ptr);
+            // Drop the contained value
+            ptr::drop_in_place(self.ptr);
 
+            // Zero-sized layouts (ZSTs and empty slices) never allocated, so there is
+            // nothing to free. Their pointer is a dangling sentinel, not a real allocation.
+            if layout.size() != 0 {
                 // Deallocate the memory
                 self.alloc.dealloc(self.ptr as *mut u8, layout);
             }
@@ -277,7 +278,11 @@ mod kani_proofs {
         let boxed = boxed.unwrap();
 
         let ptr = boxed.as_ptr();
-        assert!(ptr.is_null(), "pointer should be null for ZST");
+        assert!(
+            !ptr.is_null(),
+            "ZST pointer should be a dangling non-null sentinel"
+        );
+        assert!(ptr.is_aligned(), "ZST pointer should be well-aligned");
 
         assert_eq!(*boxed, (), "ZST value should be unit");
     }

--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -72,7 +72,7 @@ impl<T: Sized, A: Allocator> Box<T, A> {
     pub fn new_in(alloc: A, value: T) -> Result<Box<T, A>, AllocError> {
         if size_of::<T>() == 0 {
             Ok(Box {
-                ptr: ptr::null_mut(),
+                ptr: core::ptr::NonNull::<T>::dangling().as_ptr(),
                 alloc,
             })
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/nasa/spacewasm/security/code-scanning/5](https://github.com/nasa/spacewasm/security/code-scanning/5)

General fix: never store a null pointer for boxed values that may be dereferenced. For ZSTs, use a well-aligned non-null dangling pointer sentinel, matching how Rust’s standard containers represent ZST storage.

Best fix here (without changing functionality): in `Box::new_in` (around lines 73–77), replace `ptr::null_mut()` with `core::ptr::NonNull::<T>::dangling().as_ptr()`. This keeps “no allocation for ZST” behavior while guaranteeing pointer non-nullness/alignment so `deref`/`deref_mut` don’t invoke UB. No import changes are required since fully qualified path can be used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
