### PR TITLE
docs: clarify memory page terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,18 @@ time both for the Wasm module and the embedder.
 SpaceWasm has a unique dynamic memory allocation model. All of its design choices stem requirements levied by common
 flight-software standards. Dynamic allocation follows the following rules:
 
-1. All allocations occur over a discrete number of fixed size blocks called _pages_.
+SpaceWasm uses the term _page_ for three distinct units:
+
+- **Wasm linear memory pages** are the WebAssembly 1.0 unit for a module's linear memory. Each linear memory page is the
+  standard 64 KiB (65,536 bytes).
+- **Dynamic memory pages** are the fixed-size allocation blocks used by SpaceWasm's deterministic allocator to hold
+  loaded Wasm modules.
+- **IR code pages** are allocated from dynamic memory pages to store compiled IR. Each IR code page contains 256 16-bit
+  words (512 bytes) and is addressed by a 24-bit code-page index plus an 8-bit word offset.
+
+1. All allocations occur over a discrete number of fixed-size blocks called _dynamic memory pages_.
 2. Deallocation cannot precede allocation.
-3. Sub-regions inside pages cannot grow or shrink, sizes should be fixed ahead of time.
+3. Sub-regions inside dynamic memory pages cannot grow or shrink; sizes should be fixed ahead of time.
 4. Memory usage must be deterministic.
 5. Any allocation failures must _not_ result in panic.
 
@@ -80,10 +89,11 @@ resource-constrained spacecraft environments:
 
 ### IR Code Pages
 
-- **Code pages**: Configurable via generic parameter `MAX_PAGES`, typically set at module instantiation
-- **Page size**: 256 16-bit words (512 bytes)
-- **Maximum page address**: 24-bit (16,777,216 pages)
-- **Word offset in page**: 8-bit (0-255)
+- **IR code pages**: Configurable via generic parameter `MAX_PAGES`, typically set at module instantiation
+- **IR code page size**: 256 16-bit words (512 bytes)
+- **IR code-page address space**: 24-bit IR code-page index (16,777,216 addressable IR code pages); this is not a Wasm
+  linear memory page count
+- **Word offset within an IR code page**: 8-bit (0-255)
 
 ### Control Flow
 


### PR DESCRIPTION
## Summary
Edit README.md only. Add a short terminology note near the dynamic memory allocation section defining the three page kinds: (1) Wasm linear memory pages, standard 64 KiB per Wasm 1.0 (matching `PAGE_SIZE` in src/memory.rs); (2) dynamic memory pages, the fixed-size allocation blocks used by SpaceWasm's deterministic allocator; (3) IR code pages, 256 16-bit words (512 bytes) each, addressed with a 24-bit page address and 8-bit word offset. Then qualify each existing use of "page"/"pages" in the affected sections (dynamic allocation rules, "IR Code Pages") so every occurrence names its kind, e.g.

## Why this matters
MaxGraey reports that the README's memory specification is confusing because it overloads the word "page". The "IR Code Pages" section states "Page size: 256 16-bit words (512 bytes)" and "Maximum page address: 24-bit (16,777,216 pages)", which a reader can mistake for Wasm linear memory pages, even though the code (src/memory.rs line 72, `const PAGE_SIZE: usize = 65536;`) uses the standard 64 KiB linear memory page size. Maintainer Kronos3 confirmed the term is overloaded across three distinct concepts: Wasm linear memory pages, dynamic memory pages (holding loaded Wasm modules), and IR code pages (allocated from dynamic memory pages). Kronos3 agreed the documentation should carefully qualify each use of "page" but did not claim the fix.

See https://github.com/nasa/spacewasm/issues/34.

## Testing
- Happy path: rendered README distinguishes linear memory pages (64 KiB), dynamic memory pages, and IR code pages; the "512 bytes" and "16,777,216 pages" figures are unambiguously attributed to code pages. - Edge cases: grep README for remaining unqualified uses of "page" outside the terminology note; verify stated 64 KiB value matches `PAGE_SIZE = 65536` in src/memory.rs; verify 256 x 16-bit words = 512 bytes arithmetic is presented consistently. - Error paths: markdown renders correctly on GitHub (heading levels, list formatting unchanged); no changes leak outside the memory/limits sections.

Fixes #34
