### PR TITLE
Speed up Kani proofs and make sure failed allocs don't change state

### DIFF
--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -653,7 +653,11 @@ mod kani_proofs {
         let layout = Layout::from_size_align(64, 8).unwrap();
 
         let ptr1 = unsafe { page_alloc.alloc(layout) }.expect("page 0 must fit");
-        assert_eq!(page_alloc.stats().pages, 1, "First allocation must create page 0");
+        assert_eq!(
+            page_alloc.stats().pages,
+            1,
+            "First allocation must create page 0"
+        );
 
         let ptr2 = unsafe { page_alloc.alloc(layout) }.expect("page 0 must still fit");
         assert_eq!(

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -225,16 +225,16 @@ impl Page {
     /// Attempt to allocate on the tail end of this page
     fn alloc(&mut self, layout: Layout) -> Option<*mut u8> {
         // Find the next address that is aligned to this layout
-        let mut start_address = (self.ptr as usize) + self.allocated;
+        let start_address = (self.ptr as usize) + self.allocated;
         let alignment_offset = if start_address.is_multiple_of(layout.align()) {
             0
         } else {
             layout.align() - start_address % layout.align()
         };
-        start_address += alignment_offset;
+        let aligned_start = start_address + alignment_offset;
 
         // Make sure out buffer can fit in here
-        let final_offset = (start_address - self.ptr as usize) + layout.size();
+        let final_offset = (aligned_start - self.ptr as usize) + layout.size();
         if final_offset <= self.size {
             assert!(!self.has_deallocated);
             self.cache = Some(AllocCache {
@@ -246,7 +246,7 @@ impl Page {
             self.allocated = final_offset;
             self.n_allocations += 1;
 
-            Some(start_address as *mut u8)
+            Some(aligned_start as *mut u8)
         } else {
             None
         }

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -226,11 +226,12 @@ impl Page {
     fn alloc(&mut self, layout: Layout) -> Option<*mut u8> {
         // Find the next address that is aligned to this layout
         let mut start_address = (self.ptr as usize) + self.allocated;
-        if !start_address.is_multiple_of(layout.align()) {
-            let alignment_offset = layout.align() - start_address % layout.align();
-            self.wasted += alignment_offset;
-            start_address += alignment_offset;
-        }
+        let alignment_offset = if start_address.is_multiple_of(layout.align()) {
+            0
+        } else {
+            layout.align() - start_address % layout.align()
+        };
+        start_address += alignment_offset;
 
         // Make sure out buffer can fit in here
         let final_offset = (start_address - self.ptr as usize) + layout.size();
@@ -241,6 +242,7 @@ impl Page {
                 alloc_ptr: start_address,
             });
 
+            self.wasted += alignment_offset;
             self.allocated = final_offset;
             self.n_allocations += 1;
 
@@ -566,6 +568,46 @@ mod kani_proofs {
             "Page should be dropped when n_allocations reaches 0"
         );
         assert_eq!(page.n_allocations, 0, "Counter must be 0");
+
+        // Cleanup
+        core::mem::forget(page);
+        unsafe { backing_alloc.dealloc(page_ptr, page_layout) };
+    }
+
+    /// Makes sure that padding is computed correctly
+    #[kani::proof]
+    fn proof_page_alignment_padding() {
+        let backing_alloc = RustSystemAllocator;
+
+        let page_size = 128;
+        let page_layout = Layout::from_size_align(page_size, ALIGNMENT).unwrap();
+        let page_ptr = unsafe { backing_alloc.alloc(page_layout).unwrap() };
+
+        let mut page = Page::new(page_ptr, page_size);
+
+        // Leave `allocated` at an offset that is not a multiple of 8, so the
+        // next allocation attempt needs alignment padding
+        let layout1 = Layout::from_size_align(10, 8).unwrap();
+        page.alloc(layout1).expect("first allocation must fit");
+        assert_eq!(page.allocated, 10);
+        assert_eq!(page.wasted, 0);
+
+        // Needs 6 bytes of padding, but 16 + 115 = 131 > 128, so this allocation must fail
+        let layout2 = Layout::from_size_align(115, 8).unwrap();
+        let wasted_before = page.wasted;
+        let allocated_before = page.allocated;
+
+        let result = page.alloc(layout2);
+
+        assert!(result.is_none(), "allocation must fail: it does not fit");
+        assert_eq!(
+            page.wasted, wasted_before,
+            "a failed allocation must not commit alignment padding to `wasted`"
+        );
+        assert_eq!(
+            page.allocated, allocated_before,
+            "a failed allocation must not advance `allocated`"
+        );
 
         // Cleanup
         core::mem::forget(page);

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -572,84 +572,82 @@ mod kani_proofs {
         unsafe { backing_alloc.dealloc(page_ptr, page_layout) };
     }
 
-    /// Verify PageAllocator orchestration with multiple pages
+    /// Test zero-size allocation must fail
     #[kani::proof]
-    fn proof_page_allocator_correctness() {
+    fn proof_zero_size_alloc_fails() {
         let backing_alloc = RustSystemAllocator;
         let page_alloc = PageAllocator::<3>::new(&backing_alloc, 128);
 
-        // Test zero-size allocation must fail
         let zero_layout = Layout::from_size_align(0, 1).unwrap();
         let result_zero = unsafe { page_alloc.alloc(zero_layout) };
         assert!(result_zero.is_err(), "Zero-size allocation must fail");
+    }
 
-        // Test allocation too large for page size must fail
+    /// Test allocation too large for page size must fail
+    #[kani::proof]
+    fn proof_large_page_alloc_fails() {
+        let backing_alloc = RustSystemAllocator;
+        let page_alloc = PageAllocator::<3>::new(&backing_alloc, 128);
+
         let huge_layout = Layout::from_size_align(200, 8).unwrap();
         let result_huge = unsafe { page_alloc.alloc(huge_layout) };
         assert!(
             matches!(result_huge, Err(AllocError::PageTooSmall)),
             "Allocation larger than page size must fail with PageTooSmall"
         );
+    }
 
-        // Test basic allocation
-        let layout = Layout::from_size_align(32, 8).unwrap();
-        let result1 = unsafe { page_alloc.alloc(layout) };
+    /// Verify PageAllocator orchestration with multiple pages
+    ///
+    /// Each allocation is sized to exactly fill one page, so exhausting the
+    /// fixed `MAX_PAGES = 3` pages takes exactly 3 calls and the 4th call is
+    /// deterministically `OutOfMemory`. This avoids an unbounded retry loop,
+    /// which previously forced Kani to unwind many iterations (each creating
+    /// a fresh backing allocation) and blew up verification memory usage.
+    #[kani::proof]
+    fn proof_page_alloc() {
+        let backing_alloc = RustSystemAllocator;
+        let page_alloc = PageAllocator::<3>::new(&backing_alloc, 128);
+        let layout = Layout::from_size_align(128, 8).unwrap();
 
-        // If first allocation succeeds, verify properties
-        if let Ok(ptr1) = result1 {
-            // Pointer must be non-null and aligned
-            assert!(!ptr1.is_null(), "Allocated pointer must be non-null");
-            assert_eq!(ptr1 as usize % 8, 0, "Pointer must be aligned");
+        let ptr1 = unsafe { page_alloc.alloc(layout) }.expect("page 0 must fit");
+        assert!(!ptr1.is_null(), "Allocated pointer must be non-null");
+        assert_eq!(ptr1 as usize % 8, 0, "Pointer must be aligned");
 
-            let stats1 = page_alloc.stats();
-            assert!(stats1.pages >= 1, "Should have at least 1 page");
-            assert!(stats1.total_bytes >= 32, "Should track allocated bytes");
+        let stats1 = page_alloc.stats();
+        assert_eq!(stats1.pages, 1, "Should have exactly 1 page");
+        assert_eq!(stats1.total_bytes, 128, "Should track allocated bytes");
+        assert!(
+            stats1.total_bytes <= stats1.pages as u32 * 128,
+            "Total bytes must not exceed total page capacity"
+        );
+        assert!(
+            stats1.total_bytes >= stats1.pad_bytes,
+            "Total bytes must be >= pad bytes"
+        );
 
-            // Verify stats aggregation: total_bytes = allocated + wasted across all pages
-            // (We can't directly verify this without accessing page internals,
-            // but we can verify total_bytes is reasonable)
-            assert!(
-                stats1.total_bytes <= stats1.pages as u32 * ALIGNMENT as u32,
-                "Total bytes must not exceed total page capacity"
-            );
-            assert!(
-                stats1.total_bytes >= stats1.pad_bytes,
-                "Total bytes must be >= pad bytes"
-            );
+        let ptr2 = unsafe { page_alloc.alloc(layout) }.expect("page 1 must fit");
+        let ptr1_addr = ptr1 as usize;
+        let ptr2_addr = ptr2 as usize;
+        assert!(
+            ptr2_addr >= ptr1_addr + 128 || ptr1_addr >= ptr2_addr + 128,
+            "Allocations must not overlap"
+        );
 
-            // Try second allocation
-            let result2 = unsafe { page_alloc.alloc(layout) };
-            if let Ok(ptr2) = result2 {
-                // Verify no overlap
-                let ptr1_addr = ptr1 as usize;
-                let ptr2_addr = ptr2 as usize;
-                assert!(
-                    ptr2_addr >= ptr1_addr + 32 || ptr1_addr >= ptr2_addr + 32,
-                    "Allocations must not overlap"
-                );
+        let ptr3 = unsafe { page_alloc.alloc(layout) }.expect("page 2 must fit");
 
-                // Try to allocate until we run out of space
-                let result3 = unsafe { page_alloc.alloc(layout) };
-                let result4 = unsafe { page_alloc.alloc(layout) };
+        // All 3 pages (MAX_PAGES) are now full; the next call must fail
+        // deterministically, with no retry loop required.
+        let result4 = unsafe { page_alloc.alloc(layout) };
+        assert!(
+            matches!(result4, Err(AllocError::OutOfMemory)),
+            "4th allocation must fail once all pages are full"
+        );
 
-                // Eventually should run out of pages or backing memory
-                if result3.is_ok() && result4.is_ok() {
-                    // Keep trying until failure
-                    for _ in 0..10 {
-                        if unsafe { page_alloc.alloc(layout) }.is_err() {
-                            break;
-                        }
-                    }
-                    // With limited backing memory, should eventually fail
-                    // (but might not if state space exploration stops early)
-                }
-
-                // Test deallocation
-                unsafe {
-                    page_alloc.dealloc(ptr2, layout);
-                    page_alloc.dealloc(ptr1, layout);
-                }
-            }
+        unsafe {
+            page_alloc.dealloc(ptr3, layout);
+            page_alloc.dealloc(ptr2, layout);
+            page_alloc.dealloc(ptr1, layout);
         }
     }
 

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -597,15 +597,10 @@ mod kani_proofs {
         );
     }
 
-    /// Verify PageAllocator orchestration with multiple pages
-    ///
-    /// Each allocation is sized to exactly fill one page, so exhausting the
-    /// fixed `MAX_PAGES = 3` pages takes exactly 3 calls and the 4th call is
-    /// deterministically `OutOfMemory`. This avoids an unbounded retry loop,
-    /// which previously forced Kani to unwind many iterations (each creating
-    /// a fresh backing allocation) and blew up verification memory usage.
+    /// Verify that page allocations within bounds work correctly, but page allocs
+    /// that exceed total page capacity will fail
     #[kani::proof]
-    fn proof_page_alloc() {
+    fn proof_page_overalloc_failure() {
         let backing_alloc = RustSystemAllocator;
         let page_alloc = PageAllocator::<3>::new(&backing_alloc, 128);
         let layout = Layout::from_size_align(128, 8).unwrap();
@@ -636,8 +631,6 @@ mod kani_proofs {
 
         let ptr3 = unsafe { page_alloc.alloc(layout) }.expect("page 2 must fit");
 
-        // All 3 pages (MAX_PAGES) are now full; the next call must fail
-        // deterministically, with no retry loop required.
         let result4 = unsafe { page_alloc.alloc(layout) };
         assert!(
             matches!(result4, Err(AllocError::OutOfMemory)),
@@ -646,6 +639,37 @@ mod kani_proofs {
 
         unsafe {
             page_alloc.dealloc(ptr3, layout);
+            page_alloc.dealloc(ptr2, layout);
+            page_alloc.dealloc(ptr1, layout);
+        }
+    }
+
+    /// Verify that an allocation reuses an existing page with room instead
+    /// of creating a new one
+    #[kani::proof]
+    fn proof_page_alloc_reuses_existing_page() {
+        let backing_alloc = RustSystemAllocator;
+        let page_alloc = PageAllocator::<3>::new(&backing_alloc, 128);
+        let layout = Layout::from_size_align(64, 8).unwrap();
+
+        let ptr1 = unsafe { page_alloc.alloc(layout) }.expect("page 0 must fit");
+        assert_eq!(page_alloc.stats().pages, 1, "First allocation must create page 0");
+
+        let ptr2 = unsafe { page_alloc.alloc(layout) }.expect("page 0 must still fit");
+        assert_eq!(
+            page_alloc.stats().pages,
+            1,
+            "Second allocation must reuse page 0, not create a new page"
+        );
+
+        let ptr1_addr = ptr1 as usize;
+        let ptr2_addr = ptr2 as usize;
+        assert!(
+            ptr2_addr >= ptr1_addr + 64 || ptr1_addr >= ptr2_addr + 64,
+            "Allocations must not overlap"
+        );
+
+        unsafe {
             page_alloc.dealloc(ptr2, layout);
             page_alloc.dealloc(ptr1, layout);
         }


### PR DESCRIPTION
`proof_page_allocator_correctness` previously had a 10-iteration loop that blew up the search space Kani had to go through. This PR splits up the proof into 4 smaller proofs, and reduces the maximum number of pages we must allocate to check this case. We now also check that existing allocations smaller than a page share a page.

Also fixes an edge case where a failed misaligned allocation still increases wasted space

Closes #43