### PR TITLE
Regression tests for table, memory, chain function imports

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -246,9 +246,15 @@ impl Store {
                                 return Err(ValidationError::InvalidTableIndex);
                             }
 
-                            let table_ty = match &module.table {
+                            let (table_ty, resolved) = match &module.table {
                                 None => return Err(ValidationError::TableNotDefined),
-                                Some(TableKind::Owned(table)) => table.1,
+                                Some(TableKind::Owned(table)) => (
+                                    table.1,
+                                    Import::Table {
+                                        module: ModuleRef(mi as u8),
+                                        index: 0,
+                                    },
+                                ),
                                 Some(TableKind::Import(import_module_ref)) => {
                                     let r = import_module_ref.0 as usize;
                                     let Some(TableKind::Owned(table)) = &self.modules()[r].table
@@ -256,7 +262,13 @@ impl Store {
                                         unreachable!()
                                     };
 
-                                    table.1
+                                    (
+                                        table.1,
+                                        Import::Table {
+                                            module: *import_module_ref,
+                                            index: 0,
+                                        },
+                                    )
                                 }
                                 Some(TableKind::ImportHost(host_import)) => {
                                     let l = self.host_modules()[host_import.module.0 as usize]
@@ -264,10 +276,16 @@ impl Store {
                                         .value
                                         .1;
 
-                                    TableType {
-                                        elem_type: ElemType::FuncRef,
-                                        limits: l,
-                                    }
+                                    (
+                                        TableType {
+                                            elem_type: ElemType::FuncRef,
+                                            limits: l,
+                                        },
+                                        Import::HostTable {
+                                            module: host_import.module,
+                                            index: host_import.index,
+                                        },
+                                    )
                                 }
                             };
 
@@ -275,10 +293,7 @@ impl Store {
                                 return Err(ValidationError::TableImportIncompatibleSize);
                             }
 
-                            Ok(Import::Table {
-                                module: ModuleRef(mi as u8),
-                                index: 0,
-                            })
+                            Ok(resolved)
                         } else {
                             Err(ValidationError::TableImportTypeMismatch)
                         };

--- a/tests/regression/extern_funcs.wast
+++ b/tests/regression/extern_funcs.wast
@@ -1,0 +1,63 @@
+;; Chained function imports across Wasm modules and re-exported host functions
+
+(module $Af
+  (func (export "add") (param i32 i32) (result i32)
+    (i32.add (local.get 0) (local.get 1)))
+  (global (export "g") i32 (i32.const 0))
+)
+(register "Af" $Af)
+
+;; Bf re-exports a Wasm function imported from Af and a host function imported
+;; from the "regression" host module.
+(module $Bf
+  (import "Af" "add" (func $add (param i32 i32) (result i32)))
+  (import "regression" "return_i64" (func $ret64 (result i64)))
+  (export "add" (func $add))
+  (export "ret64" (func $ret64))
+)
+(register "Bf" $Bf)
+
+;; Cf imports the *re-exported* functions from Bf.
+;;   Bf."add"   resolves to Ref::Extern (an imported Wasm function)
+;;   Bf."ret64" resolves to Ref::Host   (an imported host function)
+(module $Cf
+  (import "Bf" "add" (func $add (param i32 i32) (result i32)))
+  (import "Bf" "ret64" (func $ret64 (result i64)))
+
+  (func (export "call-add") (result i32)
+    (call $add (i32.const 20) (i32.const 22)))
+  (func (export "call-ret64") (result i64)
+    (call $ret64))
+)
+
+(assert_return (invoke $Cf "call-add") (i32.const 42))
+(assert_return (invoke $Cf "call-ret64") (i64.const 4886718345))
+
+;; Signature mismatches against a host function, a local Wasm function
+;; re-exported through Ref::Extern, and a re-exported host function.
+(assert_unlinkable
+  (module (import "regression" "return_i64" (func (result i32))))
+  "incompatible import type")
+
+(assert_unlinkable
+  (module (import "Bf" "add" (func (result i32))))
+  "incompatible import type")
+
+(assert_unlinkable
+  (module (import "Bf" "ret64" (func (param i32))))
+  "incompatible import type")
+
+;; Signature mismatch against a local Wasm function (Ref::Module path).
+(assert_unlinkable
+  (module (import "Af" "add" (func (result i32))))
+  "incompatible import type")
+
+;; The named export exists but is not a function (a global imported as a func).
+(assert_unlinkable
+  (module (import "Af" "g" (func)))
+  "incompatible import type")
+
+;; Imports that name a module/field which does not exist.
+(assert_unlinkable
+  (module (import "Bf" "missing" (func)))
+  "unknown import")

--- a/tests/regression/extern_globals_chained.wast
+++ b/tests/regression/extern_globals_chained.wast
@@ -1,0 +1,92 @@
+;; Chained global imports and re-exported host globals
+
+(module $Ag
+  (global $g (export "g") (mut i32) (i32.const 100))
+  (func (export "get") (result i32) (global.get $g))
+)
+(register "Ag" $Ag)
+
+;; Bg re-exports a Wasm global imported from Ag and a mutable host global
+;; imported from the "regression" host module.
+(module $Bg
+  (global $g (import "Ag" "g") (mut i32))
+  (global $hg (import "regression" "mut_global_i64") (mut i64))
+  (export "g" (global $g))
+  (export "hg" (global $hg))
+)
+(register "Bg" $Bg)
+
+;; Cg imports the *re-exported* globals from Bg.
+;;   Bg."g"  resolves to Ref::Extern (an imported Wasm global)
+;;   Bg."hg" resolves to Ref::Host   (an imported host global)
+(module $Cg
+  (global $g (import "Bg" "g") (mut i32))
+  (global $hg (import "Bg" "hg") (mut i64))
+
+  (func (export "get") (result i32) (global.get $g))
+  (func (export "set") (param i32) (global.set $g (local.get 0)))
+
+  (func (export "get-host") (result i64) (global.get $hg))
+  (func (export "set-host") (param i64) (global.set $hg (local.get 0)))
+)
+
+(assert_return (invoke $Cg "get") (i32.const 100))
+(assert_return (invoke $Cg "set" (i32.const 7)))
+(assert_return (invoke $Cg "get") (i32.const 7))
+;; The write propagates back through the chain to the owning module Ag.
+(assert_return (invoke $Ag "get") (i32.const 7))
+
+(assert_return (invoke $Cg "set-host" (i64.const 55)))
+(assert_return (invoke $Cg "get-host") (i64.const 55))
+
+;; Type mismatch against a host global (wrong value type).
+(assert_unlinkable
+  (module (global (import "regression" "mut_global_i64") (mut i32)))
+  "incompatible import type")
+
+;; Mutability mismatch against a host global (host is mutable, import asks
+;; for immutable).
+(assert_unlinkable
+  (module (global (import "regression" "mut_global_i32") i32))
+  "incompatible import type")
+
+;; Type mismatch against a Wasm global (Ag."g" is i32, import asks for i64).
+(assert_unlinkable
+  (module (global (import "Ag" "g") (mut i64)))
+  "incompatible import type")
+
+;; Mutability mismatch against a Wasm global (Ag."g" is mutable, import asks
+;; for immutable) — the Ref::Module branch.
+(assert_unlinkable
+  (module (global (import "Ag" "g") i32))
+  "incompatible import type")
+
+;; The named export exists but is not a global (a function imported as a global).
+(assert_unlinkable
+  (module (global (import "Ag" "get") i32))
+  "incompatible import type")
+
+;; The module exists but the field does not.
+(assert_unlinkable
+  (module (global (import "Ag" "missing") i32))
+  "unknown import")
+
+;; Type mismatch against the re-exported Ref::Extern global.
+(assert_unlinkable
+  (module (global (import "Bg" "g") (mut i64)))
+  "incompatible import type")
+
+;; Type mismatch against the re-exported Ref::Host global.
+(assert_unlinkable
+  (module (global (import "Bg" "hg") (mut i32)))
+  "incompatible import type")
+
+;; Mutability mismatch against the re-exported Ref::Extern global.
+(assert_unlinkable
+  (module (global (import "Bg" "g") i32))
+  "incompatible import type")
+
+;; Mutability mismatch against the re-exported Ref::Host global.
+(assert_unlinkable
+  (module (global (import "Bg" "hg") i64))
+  "incompatible import type")

--- a/tests/regression/extern_memory.wast
+++ b/tests/regression/extern_memory.wast
@@ -1,0 +1,83 @@
+;; Chained memory imports: owned, re-exported Wasm memory, and re-exported host memory
+
+(module $Am
+  (memory (export "m") 1 2)
+  (data (i32.const 0) "\2a\00\00\00")
+)
+(register "Am" $Am)
+
+;; Bm re-exports a Wasm memory imported from Am.
+(module $Bm
+  (import "Am" "m" (memory $m 1 2))
+  (export "m" (memory $m))
+)
+(register "Bm" $Bm)
+
+;; Cm re-exports the host memory imported from "spectest" (min 1, max 2).
+(module $Cm
+  (import "spectest" "memory" (memory $m 1 2))
+  (export "m" (memory $m))
+)
+(register "Cm" $Cm)
+
+;; Dm imports the re-exported Wasm memory, exercising MemoryKind::Import.
+(module $Dm
+  (import "Bm" "m" (memory 1 2))
+  (func (export "read") (result i32)
+    (i32.load (i32.const 0)))
+  (func (export "write") (param i32)
+    (i32.store (i32.const 0) (local.get 0)))
+)
+
+;; Em imports the re-exported host memory, exercising MemoryKind::ImportHost.
+(module $Em
+  (import "Cm" "m" (memory 1 2))
+  (func (export "write-host") (param i32)
+    (i32.store (i32.const 16) (local.get 0)))
+  (func (export "read-host") (result i32)
+    (i32.load (i32.const 16)))
+)
+
+;; Reads the value placed by Am's data segment, through the import chain.
+(assert_return (invoke $Dm "read") (i32.const 42))
+;; A write propagates back to the shared owned memory in Am.
+(assert_return (invoke $Dm "write" (i32.const 123)))
+(assert_return (invoke $Dm "read") (i32.const 123))
+
+(assert_return (invoke $Em "write-host" (i32.const 77)))
+(assert_return (invoke $Em "read-host") (i32.const 77))
+
+;; Size mismatch: Am."m" has min 1, importing with a larger min cannot be satisfied.
+(assert_unlinkable
+  (module (import "Am" "m" (memory 3 4)))
+  "incompatible import type")
+
+;; Size mismatch against the re-exported Wasm memory (MemoryKind::Import).
+(assert_unlinkable
+  (module (import "Bm" "m" (memory 3 4)))
+  "incompatible import type")
+
+;; Size mismatch against the re-exported host memory (MemoryKind::ImportHost).
+(assert_unlinkable
+  (module (import "Cm" "m" (memory 3 4)))
+  "incompatible import type")
+
+;; Size mismatch directly against the host memory (min 1, max 2).
+(assert_unlinkable
+  (module (import "spectest" "memory" (memory 3 4)))
+  "incompatible import type")
+
+;; The named Wasm export exists but is not a memory (a function imported
+;; as a memory).
+(module $Fm
+  (func (export "f"))
+)
+(register "Fm" $Fm)
+(assert_unlinkable
+  (module (import "Fm" "f" (memory 1)))
+  "incompatible import type")
+
+;; Missing field in an existing module.
+(assert_unlinkable
+  (module (import "Am" "missing" (memory 1)))
+  "unknown import")

--- a/tests/regression/extern_tables.wast
+++ b/tests/regression/extern_tables.wast
@@ -1,0 +1,79 @@
+;; Chained table imports: owned, re-exported Wasm table, and re-exported host table
+
+(module $At
+  (table (export "t") 2 funcref)
+  (func $f (result i32) (i32.const 99))
+  (elem (i32.const 0) $f)
+)
+(register "At" $At)
+
+;; Bt re-exports a Wasm table imported from At.
+(module $Bt
+  (import "At" "t" (table $t 2 funcref))
+  (export "t" (table $t))
+)
+(register "Bt" $Bt)
+
+;; Ct re-exports the host table imported from "spectest".
+(module $Ct
+  (import "spectest" "table" (table $t 10 funcref))
+  (export "t" (table $t))
+)
+(register "Ct" $Ct)
+
+;; Dt imports the re-exported Wasm table (TableKind::Import resolution path)
+;; and calls indirectly through the shared owned table chain.
+(module $Dt
+  (import "Bt" "t" (table 2 funcref))
+  (type $ret_i32 (func (result i32)))
+  (func (export "call-0") (result i32)
+    (call_indirect (type $ret_i32) (i32.const 0)))
+)
+
+;; Et imports the re-exported host table (TableKind::ImportHost resolution path).
+;; Wasm 1.0 MVP only allows a single table per module.
+(module $Et
+  (import "Ct" "t" (table 10 funcref))
+)
+
+(assert_return (invoke $Dt "call-0") (i32.const 99))
+
+;; Size mismatch: At."t" has min 2, importing with a larger min is incompatible.
+(assert_unlinkable
+  (module (import "At" "t" (table 5 funcref)))
+  "incompatible import type")
+
+;; Size mismatch against the re-exported Wasm table (TableKind::Import).
+(assert_unlinkable
+  (module (import "Bt" "t" (table 5 funcref)))
+  "incompatible import type")
+
+;; Size mismatch against the re-exported host table (TableKind::ImportHost).
+(assert_unlinkable
+  (module (import "Ct" "t" (table 100 funcref)))
+  "incompatible import type")
+
+;; Size mismatch directly against the host table (min 10, max 20).
+(assert_unlinkable
+  (module (import "spectest" "table" (table 100 funcref)))
+  "incompatible import type")
+
+;; The host module exists but has no table with this field name.
+(assert_unlinkable
+  (module (import "spectest" "missing-table" (table 1 funcref)))
+  "unknown import")
+
+;; The named Wasm export exists but is not a table (a function imported
+;; as a table).
+(module $Ft
+  (func (export "f"))
+)
+(register "Ft" $Ft)
+(assert_unlinkable
+  (module (import "Ft" "f" (table 1 funcref)))
+  "incompatible import type")
+
+;; Missing field in an existing module.
+(assert_unlinkable
+  (module (import "At" "missing" (table 1 funcref)))
+  "unknown import")

--- a/tests/regression_integration.rs
+++ b/tests/regression_integration.rs
@@ -15,3 +15,23 @@ fn host_globals() {
 fn extern_globals() {
     run_wast_test_file("regression/extern_globals");
 }
+
+#[test]
+fn extern_funcs() {
+    run_wast_test_file("regression/extern_funcs");
+}
+
+#[test]
+fn extern_globals_chained() {
+    run_wast_test_file("regression/extern_globals_chained");
+}
+
+#[test]
+fn extern_tables() {
+    run_wast_test_file("regression/extern_tables");
+}
+
+#[test]
+fn extern_memory() {
+    run_wast_test_file("regression/extern_memory");
+}


### PR DESCRIPTION
Closes #22 

Found a bug in chained imports for tables which was not resolving the deep owner of the table. Logic now matches the memory linkage.