### PR TITLE
Use rust-cache for CI Rust dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,29 +76,11 @@ jobs:
           sudo cp wabt-${WABT_VERSION}/bin/* /usr/local/bin/
         shell: bash
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry/index
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-registry-
-
-      - name: Cache Cargo git
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-git-
-
-      - name: Cache build artifacts
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ matrix.profile }}-
+          key: ${{ matrix.profile }}
+          cache-bin: false
 
       - name: Run tests (debug)
         if: matrix.profile == 'debug'
@@ -227,29 +209,10 @@ jobs:
           tar -xzf wabt-${WABT_VERSION}-${WABT_PLATFORM}.tar.gz
           sudo cp wabt-${WABT_VERSION}/bin/* /usr/local/bin/
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry/index
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo git
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-git-
-
-      - name: Cache build artifacts
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-bench-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-bench-
+          cache-bin: false
 
       - name: Run CoreMark benchmark
         id: benchmark
@@ -351,21 +314,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry/index
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo git
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-git-
+          cache-bin: false
 
       - name: Generate coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,11 @@ jobs:
         shell: bash
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        # Pinned commit resolved from the annotated Swatinem/rust-cache@v2 tag.
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           key: ${{ matrix.profile }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-bin: false
 
       - name: Run tests (debug)
@@ -210,8 +212,10 @@ jobs:
           sudo cp wabt-${WABT_VERSION}/bin/* /usr/local/bin/
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        # Pinned commit resolved from the annotated Swatinem/rust-cache@v2 tag.
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-bin: false
 
       - name: Run CoreMark benchmark
@@ -315,8 +319,10 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        # Pinned commit resolved from the annotated Swatinem/rust-cache@v2 tag.
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-bin: false
 
       - name: Generate coverage


### PR DESCRIPTION
This replaces the hand-written `actions/cache` steps with `Swatinem/rust-cache@v2`.

The previous workflow cached `~/.cargo/registry`, `~/.cargo/git`, and `target` separately. `rust-cache` handles those Rust cache paths directly, while also taking care of Rust-specific cache keys, pruning stale build artifacts, and setting `CARGO_INCREMENTAL=0` for CI builds.

ref: https://github.com/swatinem/rust-cache