### PR TITLE
Add in copyright notice for Rust and circular-buffer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,37 +22,6 @@ Copyright (c) The Rust Project Developers.
 
 ---
 
-This product includes software developed by the [circular-buffer](https://github.com/andreacorbellini/rust-circular-buffer) crate.
-
-Copyright (c) 2023, 2024 Andrea Corbellini and contributors
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
 This product includes software developed by [DLR](https://github.com/DLR-FT/wasm-interpreter).
 
 Copyright (c) 2024-2026 Deutsches Zentrum fuer Luft- und Raumfahrt e.V. (DLR)
@@ -92,3 +61,34 @@ Copyright © 2009 EEMBC All rights reserved. CoreMark is a trademark of EEMBC an
 This product includes software developed by [wasm3](https://github.com/wasm3/wasm-coremark).
 No license file is provided upstream. The wrapped CoreMark payload is governed
 by the COREMARK ACCEPTABLE USE AGREEMENT noted above.
+
+---
+
+This product includes software developed by the [circular-buffer](https://github.com/andreacorbellini/rust-circular-buffer) crate.
+
+Copyright (c) 2023, 2024 Andrea Corbellini and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -12,6 +12,47 @@ portions, their upstream projects, and their licenses are listed below.
 
 ---
 
+This product includes software developed by [Rust](https://github.com/rust-lang/rust).
+
+Portions of the memory utilities are derived from the Rust standard library.
+The Rust project is dual-licensed under MIT OR Apache-2.0; these portions are
+used under the Apache License, Version 2.0.
+
+Copyright (c) The Rust Project Developers.
+
+---
+
+This product includes software developed by the [circular-buffer](https://github.com/andreacorbellini/rust-circular-buffer) crate.
+
+Copyright (c) 2023, 2024 Andrea Corbellini and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
 This product includes software developed by [DLR](https://github.com/DLR-FT/wasm-interpreter).
 
 Copyright (c) 2024-2026 Deutsches Zentrum fuer Luft- und Raumfahrt e.V. (DLR)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Currently, all other proposals are not planned or considered.
 
 Portions of this project are adapted from the open-source projects:
 
+- [rust-lang/rust](https://github.com/rust-lang/rust), which is dual-licensed under MIT OR Apache License 2.0.
 - [DLR-FT/wasm-interpreter](https://github.com/DLR-FT/wasm-interpreter), which is licensed under the Apache License 2.0.
 - [Wasmtime](https://github.com/bytecodealliance/wasmtime), which is licensed under the Apache License 2.0 with LLVM-exception.
 - [WABT](https://github.com/webassembly/wabt), which is licensed under the Apache License 2.0.

--- a/src/util/alloc.rs
+++ b/src/util/alloc.rs
@@ -1,3 +1,7 @@
+// Portions of this file are derived from the Rust project
+// (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
+// portions have been modified for SpaceWasm.
+
 use core::{alloc::Layout, marker::PhantomData};
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -1,3 +1,7 @@
+// Portions of this file are derived from the Rust project
+// (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
+// portions have been modified for SpaceWasm.
+
 use crate::StaticAllocator;
 use crate::alloc::{AllocError, Allocator, GlobalAllocator};
 use crate::util::Vec;

--- a/src/util/circular_buffer.rs
+++ b/src/util/circular_buffer.rs
@@ -1,3 +1,9 @@
+// Portions of this file are derived from the circular-buffer crate
+// (https://github.com/andreacorbellini/rust-circular-buffer), Copyright (c)
+// 2023, 2024 Andrea Corbellini and contributors, licensed under BSD-3-Clause.
+// These portions have been modified for SpaceWasm. See the NOTICE file for the
+// full license text.
+
 use core::mem::MaybeUninit;
 use core::ptr;
 

--- a/src/util/rc.rs
+++ b/src/util/rc.rs
@@ -1,3 +1,7 @@
+// Portions of this file are derived from the Rust project
+// (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
+// portions have been modified for SpaceWasm.
+
 use crate::{AllocError, Allocator, GlobalAllocator};
 use core::cell::Cell;
 use core::fmt::{Debug, Formatter};

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -1,3 +1,7 @@
+// Portions of this file are derived from the Rust project
+// (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
+// portions have been modified for SpaceWasm.
+
 use crate::util::Vec;
 use crate::{Allocator, GlobalAllocator, ValidationError};
 use core::fmt;

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -1,3 +1,7 @@
+// Portions of this file are derived from the Rust project
+// (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
+// portions have been modified for SpaceWasm.
+
 use crate::Box;
 use crate::alloc::{AllocError, Allocator, GlobalAllocator};
 use crate::util::InnerVec;


### PR DESCRIPTION
I forgot to add some additional notices of software I referenced.