### PR TITLE
Replace unsafe MaybeUninit array initialization

### DIFF
--- a/src/util/circular_buffer.rs
+++ b/src/util/circular_buffer.rs
@@ -25,7 +25,7 @@ impl<T, const N: usize> CircularBuffer<T, N> {
         Self {
             size: 0,
             start: 0,
-            items: unsafe { MaybeUninit::uninit().assume_init() },
+            items: [const { MaybeUninit::uninit() }; N],
         }
     }
 

--- a/src/util/static_vec.rs
+++ b/src/util/static_vec.rs
@@ -37,7 +37,7 @@ impl<T: Sized, const N: usize> StaticVec<T, N> {
 impl<T: Sized, const N: usize> Default for StaticVec<T, N> {
     fn default() -> Self {
         Self {
-            data: unsafe { MaybeUninit::uninit().assume_init() },
+            data: [const { MaybeUninit::uninit() }; N],
             len: 0,
         }
     }


### PR DESCRIPTION
Replace
```rust
    unsafe { MaybeUninit::uninit().assume_init() }
```
with
```rust
    [const { MaybeUninit::uninit() }; N]
```
This removes two unnecessary `unsafe` blocks while preserving the same behavior.

And the project's MSRV (Rust 1.87) supports this initialization pattern.

Reference: [rust-lang/rust RELEASES.md#version-1790-2024-06-13](https://github.com/rust-lang/rust/blob/9fa33b19f76b5b3173280b7a8e306bf8f6241344/RELEASES.md#version-1790-2024-06-13) [rust-lang/rust#104087](https://github.com/rust-lang/rust/pull/104087/)

AI disclosure: ChatGPT was used to look up when const array initialization (`[const { ... }; N]`) became available and to confirm that it is supported by the project's MSRV. The code change was implemented, reviewed, and tested manually.