### PR TITLE
Avoid let chains to preserve MSRV 1.87

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -202,29 +202,28 @@ impl Memory {
 
         let old_size = self.size;
         let new_size = (Self::PAGE_SIZE * n as usize) + self.size;
-        if let Some(allocator) = &self.allocator
-            && let Some(ptr) = NonNull::new(self.ptr)
-        {
-            self.ptr = allocator
-                .reallocate(
-                    ptr,
-                    Layout::from_size_align(old_size, 16).unwrap(),
-                    Layout::from_size_align(new_size, 16).unwrap(),
-                )?
-                .as_ptr();
+        if let Some(allocator) = &self.allocator {
+            if let Some(ptr) = NonNull::new(self.ptr) {
+                self.ptr = allocator
+                    .reallocate(
+                        ptr,
+                        Layout::from_size_align(old_size, 16).unwrap(),
+                        Layout::from_size_align(new_size, 16).unwrap(),
+                    )?
+                    .as_ptr();
 
-            // Clear the new memory
-            let new_ptr = unsafe { self.ptr.add(old_size) };
-            unsafe {
-                new_ptr.write_bytes(0, Self::PAGE_SIZE * n as usize);
+                // Clear the new memory
+                let new_ptr = unsafe { self.ptr.add(old_size) };
+                unsafe {
+                    new_ptr.write_bytes(0, Self::PAGE_SIZE * n as usize);
+                }
+
+                self.size = new_size;
+
+                return Ok((old_size / Self::PAGE_SIZE) as u32);
             }
-
-            self.size = new_size;
-
-            Ok((old_size / Self::PAGE_SIZE) as u32)
-        } else {
-            Err(MemoryError::OutOfMemory)
         }
+        Err(MemoryError::OutOfMemory)
     }
 
     pub fn mem_type(&self) -> MemType {

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,11 +263,7 @@ impl MemType {
         let limit = Limit::read(wasm)?;
 
         // Validate the memory limits
-        if limit.min > 65536 {
-            Err(ValidationError::MemoryTooLarge)
-        } else if let Some(max) = limit.max
-            && max > 65536
-        {
+        if limit.min > 65536 || matches!(limit.max, Some(max) if max > 65536) {
             Err(ValidationError::MemoryTooLarge)
         } else {
             Ok(MemType(limit))

--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -262,13 +262,13 @@ impl Page {
             assert!(self.n_allocations > 0);
 
             // Check is we can deallocate this pointer without marking this page with a dealloc flag
-            if let Some(cache) = self.cache.take()
-                && cache.alloc_ptr == dealloc_ptr
-            {
-                self.n_allocations -= 1;
-                self.allocated = cache.restore_ptr - page_ptr;
-                self.wasted -= dealloc_ptr - cache.restore_ptr;
-                return Some(self.n_allocations == 0);
+            if let Some(cache) = self.cache.take() {
+                if cache.alloc_ptr == dealloc_ptr {
+                    self.n_allocations -= 1;
+                    self.allocated = cache.restore_ptr - page_ptr;
+                    self.wasted -= dealloc_ptr - cache.restore_ptr;
+                    return Some(self.n_allocations == 0);
+                }
             };
 
             // FIXME(tumbar) We may want to track used regions of the pages


### PR DESCRIPTION
The current code uses `let` chains, which were stabilized in Rust 1.88, while the project declares an MSRV of Rust 1.87.

https://github.com/nasa/spacewasm/blob/e24cf09355a90497148eb5029fdb8e3400bd63e3/Cargo.toml#L12

```console
error[E0658]: `let` expressions in this position are unstable
   --> src/util/paging.rs:265:16
    |
265 |             if let Some(cache) = self.cache.take()
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> src/types.rs:268:19
    |
268 |         } else if let Some(max) = limit.max
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> src/memory.rs:205:12
    |
205 |         if let Some(allocator) = &self.allocator
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> src/memory.rs:206:16
    |
206 |             && let Some(ptr) = NonNull::new(self.ptr)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `spacewasm` (lib) due to 4 previous errors
```

Reference: [rust-lang/rust RELEASE.md#version-1880-2025-06-26](https://github.com/rust-lang/rust/blob/9fa33b19f76b5b3173280b7a8e306bf8f6241344/RELEASES.md#version-1880-2025-06-26)

AI disclosure: I discovered this issue by building the project with its declared MSRV (cargo +1.87 check). ChatGPT was used to confirm the stabilization version of let chains and to sanity-check that the rewritten control flow was behaviorally equivalent. All code changes were implemented and tested manually.