### PR TITLE
docs: adversarial testing pattern for flight-compliant WASM modules

### DIFF
--- a/docs/ADVERSARIAL_TESTING.md
+++ b/docs/ADVERSARIAL_TESTING.md
@@ -1,0 +1,28 @@
+# Adversarial Testing for SpaceWasm Modules
+
+SpaceWasm is a flight-compliant WebAssembly interpreter.
+This doc describes dual-model adversarial test generation.
+
+## Threat Model
+
+Flight WASM modules may receive malformed sensor inputs,
+out-of-bounds indices from corrupted telemetry,
+or unexpected state transitions from concurrent systems.
+
+## Dual-Model Gate Pattern
+
+```
+Generator model  ->  happy-path test cases
+     down
+Adversarial gate  ->  boundary values, type confusion,
+    sequence attacks, resource exhaustion
+     down
+SpaceWasm  ->  runs all cases under fuel limit
+```
+
+## Key Invariants
+
+1. Fuel-bounded execution -- no unbounded runs
+2. Memory-safe -- no access outside declared pages
+3. Deterministic -- same inputs, same outputs
+4. No host imports outside whitelist


### PR DESCRIPTION
## Summary

- Adds `docs/ADVERSARIAL_TESTING.md` — dual-model adversarial test generation pattern for SpaceWasm modules

## Motivation

Flight WASM modules need adversarial test coverage beyond happy-path unit tests. A gate model loaded with the SpaceWasm fuel/memory constraints generates boundary-value and type-confusion cases that exercise the interpreter's safety invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — EDAULC, SNAPKITTYWEST