### PR TITLE
Switch to thin LTO in builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,12 +49,12 @@ spacewasm = { path = ".", features = ["strict-assertions"] }
 
 [profile.release]
 opt-level = 3
-lto = true
+lto = "thin"
 debug = "full"
 strip = false
 codegen-units = 1
 
 [profile.bench]
 opt-level = 3
-lto = true
+lto = "thin"
 codegen-units = 1


### PR DESCRIPTION
Enabling [thin LTO](https://ieeexplore.ieee.org/abstract/document/7863733) allows projects including SpaceWasm as a sub-project that want to do full-project LTO and PGO to use LTO results from release binaries. Should also speed up compilations a little bit.