### PR TITLE
Add kani proofs for IR encoding edge cases

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1717,3 +1717,87 @@ impl<'store> IrVisitor for Interpreter<'store> {
 #[cfg(test)]
 #[path = "interpreter_tests.rs"]
 mod interpreter_tests;
+
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    /// Verify CallFrame transmute correctness
+    #[kani::proof]
+    fn proof_callframe_transmute_roundtrip() {
+        let frame_length: u16 = kani::any();
+        let module_delta: u8 = kani::any();
+        let parameter_size: u8 = kani::any();
+
+        let frame = CallFrame {
+            frame_length,
+            module_delta,
+            parameter_size,
+        };
+
+        let bits = frame.into_bits();
+
+        let decoded = CallFrame::from_bits(bits);
+
+        assert_eq!(
+            decoded.frame_length, frame_length,
+            "frame_length must round-trip correctly"
+        );
+        assert_eq!(
+            decoded.module_delta, module_delta,
+            "module_delta must round-trip correctly"
+        );
+        assert_eq!(
+            decoded.parameter_size, parameter_size,
+            "parameter_size must round-trip correctly"
+        );
+    }
+
+    /// Verify CallFrame transmute produces deterministic results
+    #[kani::proof]
+    fn proof_callframe_deterministic() {
+        let frame_length: u16 = kani::any();
+        let module_delta: u8 = kani::any();
+        let parameter_size: u8 = kani::any();
+
+        let frame1 = CallFrame {
+            frame_length,
+            module_delta,
+            parameter_size,
+        };
+
+        let frame2 = CallFrame {
+            frame_length,
+            module_delta,
+            parameter_size,
+        };
+
+        let bits1 = frame1.into_bits();
+        let bits2 = frame2.into_bits();
+
+        assert_eq!(bits1, bits2, "Same inputs must produce same bit pattern");
+    }
+
+    /// Verify CallFrame layout should pack into 32 bits
+    #[kani::proof]
+    fn proof_callframe_layout() {
+        assert_eq!(
+            core::mem::size_of::<CallFrame>(),
+            4,
+            "CallFrame must be exactly 4 bytes"
+        );
+
+        let frame = CallFrame {
+            frame_length: 0x1234,
+            module_delta: 0x56,
+            parameter_size: 0x78,
+        };
+
+        let bits = frame.into_bits();
+        let decoded = CallFrame::from_bits(bits);
+
+        assert_eq!(decoded.frame_length, 0x1234);
+        assert_eq!(decoded.module_delta, 0x56);
+        assert_eq!(decoded.parameter_size, 0x78);
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -1186,7 +1186,10 @@ mod kani_proofs {
 
         assert_eq!(decoded_depth, depth, "Depth must decode correctly");
 
-        assert_eq!(decoded_offset.0, offset.0, "Offset must decode correctly with proper sign extension");
+        assert_eq!(
+            decoded_offset.0, offset.0,
+            "Offset must decode correctly with proper sign extension"
+        );
     }
 
     /// Verify JumpOffset::new() validation only accepts offsets in [-2^21, 2^21-1]
@@ -1208,13 +1211,22 @@ mod kani_proofs {
         let fits_in_22_bits = offset == ((offset << 10) >> 10);
 
         if fits_in_22_bits {
-            assert!(result.is_ok(), "Offset within 22-bit range should be accepted");
+            assert!(
+                result.is_ok(),
+                "Offset within 22-bit range should be accepted"
+            );
 
             if let Ok(jump_offset) = result {
-                assert_eq!(jump_offset.0, offset, "Accepted offset should match computed value");
+                assert_eq!(
+                    jump_offset.0, offset,
+                    "Accepted offset should match computed value"
+                );
             }
         } else {
-            assert!(result.is_err(), "Offset outside 22-bit range should be rejected");
+            assert!(
+                result.is_err(),
+                "Offset outside 22-bit range should be rejected"
+            );
         }
     }
 
@@ -1250,10 +1262,17 @@ mod kani_proofs {
 
         let result = JumpOffset::new(current_target, sentinel);
 
-        assert!(result.is_ok(), "Creating offset to SENTINEL should always succeed");
+        assert!(
+            result.is_ok(),
+            "Creating offset to SENTINEL should always succeed"
+        );
 
         if let Ok(offset) = result {
-            assert_eq!(offset, JumpOffset::sentinel(), "Offset to SENTINEL should be sentinel");
+            assert_eq!(
+                offset,
+                JumpOffset::sentinel(),
+                "Offset to SENTINEL should be sentinel"
+            );
             assert_eq!(offset.0, 0, "Sentinel offset should be 0");
         }
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1145,3 +1145,116 @@ impl<'a, const MAX_CODE_PAGES: usize, const MAX_CONTROL_FRAMES: usize, const MAX
         Ok(())
     }
 }
+
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    /// Verify LabelTarget encoding/decoding correctness
+    #[kani::proof]
+    fn proof_label_target_roundtrip() {
+        let type_selector: u8 = kani::any();
+        let depth: u8 = kani::any();
+        let offset_raw: i32 = kani::any();
+
+        // Constrain offset to 22-bit signed range
+        kani::assume(offset_raw >= -(1 << 21) && offset_raw < (1 << 21));
+
+        let result_type = match type_selector % 5 {
+            0 => ResultType(None),
+            1 => ResultType(Some(ValType::I32)),
+            2 => ResultType(Some(ValType::I64)),
+            3 => ResultType(Some(ValType::F32)),
+            4 => ResultType(Some(ValType::F64)),
+            _ => unreachable!(),
+        };
+
+        let offset = JumpOffset(offset_raw);
+
+        let label = LabelTarget::new(result_type, depth, offset);
+
+        let decoded_arity = label.arity();
+        let decoded_depth = label.depth();
+        let decoded_offset = label.jump();
+
+        let expected_arity = match result_type.0 {
+            None => LabelArity::None,
+            Some(ValType::I32 | ValType::F32) => LabelArity::I32,
+            Some(ValType::I64 | ValType::F64) => LabelArity::I64,
+        };
+        assert_eq!(decoded_arity, expected_arity, "Arity must decode correctly");
+
+        assert_eq!(decoded_depth, depth, "Depth must decode correctly");
+
+        assert_eq!(decoded_offset.0, offset.0, "Offset must decode correctly with proper sign extension");
+    }
+
+    /// Verify JumpOffset::new() validation only accepts offsets in [-2^21, 2^21-1]
+    #[kani::proof]
+    fn proof_jump_offset_validation() {
+        let current: u32 = kani::any();
+        let to: u32 = kani::any();
+
+        kani::assume(current < (1 << 30));
+        kani::assume(to < (1 << 30));
+
+        let current_target = JumpTarget(current);
+        let to_target = JumpTarget(to);
+
+        let result = JumpOffset::new(current_target, to_target);
+
+        let offset = (to as i32).wrapping_sub(current as i32);
+
+        let fits_in_22_bits = offset == ((offset << 10) >> 10);
+
+        if fits_in_22_bits {
+            assert!(result.is_ok(), "Offset within 22-bit range should be accepted");
+
+            if let Ok(jump_offset) = result {
+                assert_eq!(jump_offset.0, offset, "Accepted offset should match computed value");
+            }
+        } else {
+            assert!(result.is_err(), "Offset outside 22-bit range should be rejected");
+        }
+    }
+
+    /// Verify JumpTarget + JumpOffset arithmetic works correctly
+    #[kani::proof]
+    fn proof_jump_target_addition() {
+        let pc: u32 = kani::any();
+        let offset_raw: i32 = kani::any();
+
+        kani::assume(pc < (1 << 30));
+        kani::assume(offset_raw >= -(1 << 21) && offset_raw < (1 << 21));
+
+        let target = JumpTarget(pc);
+        let offset = JumpOffset(offset_raw);
+
+        let result = target + offset;
+
+        let expected = ((pc as i32).wrapping_add(offset_raw)) as u32;
+        assert_eq!(
+            result.0, expected,
+            "JumpTarget + JumpOffset should compute correct address"
+        );
+    }
+
+    /// Verify that sentinel jump targets work correctly
+    #[kani::proof]
+    fn proof_jump_offset_sentinel() {
+        let current: u32 = kani::any();
+        kani::assume(current < (1 << 30));
+
+        let current_target = JumpTarget(current);
+        let sentinel = JumpTarget::SENTINEL;
+
+        let result = JumpOffset::new(current_target, sentinel);
+
+        assert!(result.is_ok(), "Creating offset to SENTINEL should always succeed");
+
+        if let Ok(offset) = result {
+            assert_eq!(offset, JumpOffset::sentinel(), "Offset to SENTINEL should be sentinel");
+            assert_eq!(offset.0, 0, "Sentinel offset should be 0");
+        }
+    }
+}

--- a/src/util/rc.rs
+++ b/src/util/rc.rs
@@ -860,6 +860,24 @@ mod kani_proofs {
         );
     }
 
+    /// Make sure new_slice_with_default_in works as expected
+    #[kani::proof]
+    fn proof_rc_new_slice_with_default() {
+        let len: usize = kani::any();
+        kani::assume(len <= 2); // Keep state explosion away
+
+        let rc: Result<Rc<[u32], _>, _> = Rc::new_slice_with_default_in(RustSystemAllocator, len);
+        kani::assume(rc.is_ok());
+        let rc = rc.unwrap();
+
+        assert_eq!(rc.len(), len, "Slice length must match requested length");
+        assert_eq!(rc.inner().count(), 1, "Count must be 1");
+
+        if len > 0 {
+            assert_eq!(rc[0], 0u32, "First element must be default-initialized to 0");
+        }
+    }
+
     /// Verify Rc deref returns correct value and doesn't violate aliasing
     #[kani::proof]
     fn proof_rc_deref_correctness() {

--- a/src/util/rc.rs
+++ b/src/util/rc.rs
@@ -860,24 +860,6 @@ mod kani_proofs {
         );
     }
 
-    /// Make sure new_slice_with_default_in works as expected
-    #[kani::proof]
-    fn proof_rc_new_slice_with_default() {
-        let len: usize = kani::any();
-        kani::assume(len <= 2); // Keep state explosion away
-
-        let rc: Result<Rc<[u32], _>, _> = Rc::new_slice_with_default_in(RustSystemAllocator, len);
-        kani::assume(rc.is_ok());
-        let rc = rc.unwrap();
-
-        assert_eq!(rc.len(), len, "Slice length must match requested length");
-        assert_eq!(rc.inner().count(), 1, "Count must be 1");
-
-        if len > 0 {
-            assert_eq!(rc[0], 0u32, "First element must be default-initialized to 0");
-        }
-    }
-
     /// Verify Rc deref returns correct value and doesn't violate aliasing
     #[kani::proof]
     fn proof_rc_deref_correctness() {


### PR DESCRIPTION
Proves correctness for:

* LabelTarget encoding and decoding always works correctly
* CallFrame transmute works correctly for all inputs
* Offset validation always produces a valid offset
* PC calculation arithmetic always produces a valid PC location