### PR TITLE
Fix the bound asserted on parameter size when functions are called

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -98,7 +98,7 @@ impl<'store> InterpreterState<'store> {
         // We need to push the frame pointer and the return instruction pointer to the stack
         // We also encode the parameter size into the stack frame so that the return can unwind the stack
         let frame_length = (self.sp - self.fp as usize) as u32;
-        assert!(frame_length <= 0xFFFFF);
+        assert!(frame_length <= 0xFFFF);
         let frame = CallFrame {
             frame_length: frame_length as u16,
             module_delta,


### PR DESCRIPTION
When a function is called, parameters are pushed on the stack and their size is saved in `struct CallFrame` as a `u16` integer. Before casting to `u16`, a check was done:

```rust
assert!(frame_length <= 0xFFFFF);
```

When `frame_length` was between `0x10000` and `0xFFFFF`, its value was silently truncated when it was cast to `u16`

Fix the bound to actually match `u16::MAX`.

_Disclosure of usage of AI_:
- I used AI to identify this bug, by prompting "Identify issues related to the WASM specification and guarantees" in Claude Code with model Sonnet 4.6.
- I have not used any Generative AI to review the generated bug report, write the fix, test the fix (using `cargo test`) and write this Pull Request.