### PR TITLE
Fix initialization of AllocCache

### DIFF
--- a/src/util/paging.rs
+++ b/src/util/paging.rs
@@ -238,8 +238,8 @@ impl Page {
         if final_offset <= self.size {
             assert!(!self.has_deallocated);
             self.cache = Some(AllocCache {
-                restore_ptr: (self.ptr as usize) + self.allocated,
-                alloc_ptr: start_address,
+                restore_ptr: start_address,
+                alloc_ptr: aligned_start,
             });
 
             self.wasted += alignment_offset;


### PR DESCRIPTION
Pull Request https://github.com/nasa/spacewasm/pull/59 ("Speed up Kani proofs and make sure failed allocs don't change state") modified `util::paging::Page::alloc`, renaming `start_address` to `aligned_start` without updating the initialization of `self.cache`. As a consequence, both fields `restore_ptr` and `alloc_ptr` were equal and the matching logic in `dealloc` was not sound.

Use the right variable for `alloc_ptr`. While at it, re-use variable `start_address` to initialize `restore_ptr` instead of computing twice the same value.

## Context

I was looking at this function after Miri complained about an integer-to-pointer cast in https://github.com/nasa/spacewasm/blob/d29addd6b404d2a972f8f4d89ed64a5fb66fdcab/src/util/paging.rs#L249

```text
$ cargo +nightly miri test util::paging::tests
...
test util::paging::tests::test_full_reclaim_after_non_lifo_frees ... warning: integer-to-pointer cast
   --> src/util/paging.rs:249:18
    |
249 |             Some(aligned_start as *mut u8)
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer cast
    |
    = help: this program is using integer-to-pointer casts or (equivalently) `ptr::with_exposed_provenance`, which means that Miri might miss pointer bugs in this program
    = help: see https://doc.rust-lang.org/nightly/std/ptr/fn.with_exposed_provenance.html for more details on that operation
    = help: to ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
    = help: you can then set `MIRIFLAGS=-Zmiri-strict-provenance` to ensure you are not relying on `with_exposed_provenance` semantics
    = help: alternatively, `MIRIFLAGS=-Zmiri-permissive-provenance` disables this warning
    = note: this is on thread `util::paging::t`
```

Fixing this warning requires calling some `unsafe` function, to perform raw pointer arithmetic, and I guess the current implementation tries to avoid unsafe code as much as possible. So I am not suggesting to change this, but while looking at the code, I found the semantics of `AllocCache` a bit weird. Looking deeper made me believe it was an actual bug, not caught by the current test suite or Kani proofs.