### PR TITLE
Remove CI codecov hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,10 +336,6 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-bin: false
 
-      - name: Remove SVGs before coverage analysis
-        # Baffling issue with codecov breaking after I added the icon
-        run: rm -rf docs/logo.svg
-
       - name: Generate coverage
         run: |
           # Cover the main library and the C-API layer. spacewasm_c_api's Rust


### PR DESCRIPTION
Looks like the codecov issues are due to a codecov backend problem https://status.codecov.com/incidents/mqzsjlz06dfr. This hack is not needed.