### PR TITLE
docs: add Chinese and Japanese READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,209 @@
+<h1 align="center">SpaceWasm</h2>
+
+<p align="center">
+<img src="docs/logo.svg" width="150" height="150">
+</p>
+
+<p align="center">
+  <a href="https://github.com/nasa/spacewasm/actions/workflows/ci.yml"><img src="https://github.com/nasa/spacewasm/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="https://codecov.io/gh/nasa/spacewasm"><img src="https://codecov.io/gh/nasa/spacewasm/graph/badge.svg?token=3EddiLtM36"/></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="license" /></a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語
+</p>
+
+SpaceWasm は、宇宙機上で Wasm バイナリを解釈するための
+[Wasm 1.0](https://webassembly.github.io/spec/versions/core/WebAssembly-1.0.pdf) 仕様の実装です。[NASA JPL](https://www.jpl.nasa.gov) で開発されています。
+
+## 理由
+
+1. **シーケンシング**：宇宙機の高レベルな活動は通常、組み込みフライトソフトウェアの外部でコマンドシーケンスとして記述されます。
+こうした活動には、火星探査車の走行やアームの操作から、温度範囲が正常かどうかの確認まで、さまざまなものがあります。
+これまでシーケンスの形式と機能はミッションごとに異なり、多様で断片化した実装が生じていました。
+SpaceWasm は業界標準を実装し、これらを統合します。
+
+2. **サンドボックス化**：フライトソフトウェアの開発は、要件と対象範囲が厳しく制約されるため、コストと時間がかかります。新しいフライトソフトウェア機能の検証では、
+システム全体との相互作用を検証しなければならないことがよくあります。そのため V&V の期間が長くなり、テストベッド資源の競合も激しくなり、新しい自律ソフトウェアを
+実際の飛行に導入することが難しくなります。WebAssembly を使用すれば、信頼できない、または信頼度の低い実行ファイルを宇宙機に搭載しつつ、
+フライトソフトウェア側でアクセス権限と計算時間を制限し、健全性と安全性を監視できます。
+
+3. **可搬性**：WebAssembly は明確に定義されたインターフェースとサンドボックス機構を備えているため、別のプラットフォームへの移植が容易です。
+
+4. **ツール**：WebAssembly を標準とすることで、豊富なツールと研究成果を持つ広範なコミュニティを活用できます！
+
+## 概要
+
+このソフトウェアは、次の 2 つの主要コンポーネントで構成されています。
+
+1. デコーダー／バリデーター：
+
+   Wasm バイナリを[チャンク](#ストリーミング)単位で読み込み、実行可能な形式にデコードします。デコーダーが使用するメモリ量は固定されており、
+   地上では `spacewasm-check` 実行ファイルを使用して Wasm バイナリごとに測定できます。
+
+   WebAssembly はデコード中に検証されるため、バイトコードをもう一度走査する必要はありません。
+
+2. インタープリタ：
+
+   線形メモリ上で動作し、[組み込み](#組み込み)側から提供されるフックと連携できる
+   Wasm インタープリタです。
+
+SpaceWasm は WebAssembly バイトコードを直接実行しません。Wasm バイトコードは小さく、検証しやすい構造になるよう設計されていますが、
+その性質のため、そのまま実行すると低速です。SpaceWasm は Wasm 命令のデコード中に、
+バイトコードを解釈実行に適した特性を持つ別の中間表現（IR）へ変換します。IR の詳細については
+[仕様](src/SPEC.md)を参照してください。
+
+## 要件
+
+SpaceWasm の要件は、[DLR](https://github.com/DLR-FT/wasm-interpreter) による類似の取り組みを基に定められています。
+
+[要件](./REQUIREMENTS.md)を参照してください。
+
+## 組み込み
+
+インタープリタの組み込みとは、インタープリタをインスタンス化し、モジュールがインポートする関数の実装を提供することです。
+通常、モジュールがインポートする関数の集合は固定されており、Wasm モジュール側と組み込み側の両方で
+コンパイル時に指定する必要があります。
+
+## 動的割り当て
+
+SpaceWasm は独自の動的メモリ割り当てモデルを採用しています。設計上の選択はすべて、一般的なフライトソフトウェア標準の要件に基づいています。
+動的割り当ては次の規則に従います。
+
+1. すべての割り当ては、_ページ_と呼ばれる一定数の固定サイズブロック単位で行われます。これらのページは Wasm の線形メモリページとは異なります。
+2. 割り当てより前に解放を行うことはできません。
+3. ページ内の部分領域は拡大も縮小もできず、サイズを事前に固定する必要があります。
+4. メモリ使用量は決定論的でなければなりません。
+5. 割り当てが失敗しても panic を引き起こしては_なりません_。
+
+Rust 標準の[アロケーション](https://doc.rust-lang.org/alloc/)は、カスタムアロケータを使用してもこれらの制約を満たしません。
+そのため SpaceWasm は、これらの性質を保証する独自のデータ構造を提供しています。これらのデータ構造だけが、
+プロジェクト内で Rust の `unsafe` セマンティクスを使用しています。
+
+> [!NOTE]
+> これらの制限はインタープリタの実装にのみ適用され、解釈対象の Wasm バイトコードには適用され_ません_。
+
+Wasm の線形メモリページは、動的メモリページの外部に割り当てられます。
+
+## ストリーミング
+
+宇宙機に搭載される小型システムでは、_ピーク_メモリ使用量が重要な制約になることがよくあります。多くの Wasm インタープリタは、
+Wasm バイナリ全体を 1 つの連続したデータとして渡す必要があります。同じメモリ領域を異なる目的で再利用できるシステムでは、
+通常これは問題になりません。しかし、宇宙機のフライトソフトウェアでは一般に、特定の用途ごとに固定のメモリ領域が割り当てられます。
+したがって、Wasm バイナリ全体を単一の連続領域に収めることは現実的ではありません。
+
+SpaceWasm は、ピークメモリ使用量を減らし、ストリーミングに必要な割り当て後の解放を不要にするよう高度に最適化されています。
+そのため、WebAssembly 仕様にはいくつかの[制約](#インタープリタの制限)が課されています。
+
+SpaceWasm はストリーミング機構により、Wasm バイナリを 1 回の走査でデコードおよびコンパイルできます。ファイルシステムから
+Wasm バイナリのチャンクを読み取る、または要求するたびに、それをインタープリタへ渡せます。ストリームはチャンクを同期的に提供する必要があります。
+
+
+## WASI 0.1 サポート
+[`spacewasi`](crates/spacewasi#readme) crate は、WASI 0.1（`wasip1`）仕様に準拠する任意の WASM モジュールをサンドボックス環境で実行できるバイナリを提供します。コマンドラインフラグを使用して、ホストのディレクトリと環境変数をマウントできます。
+
+```bash
+# compile example from crates/spacewasi/tests/wasm/
+$ clang --target=wasm32-wasip1 -mcpu=mvp hello_universe.c -o hello_universe.wasm
+
+# convert module to MVP compatible file
+$ crates/spacewasi/scripts/wasm2mvp.sh hello_universe.wasm
+
+$ spacewasi hello_universe.wasm
+hello universe!
+```
+
+このコマンドと WASI の基本的なコンパイル方法については、[`spacewasi/README.md`](crates/spacewasi/README.md)を参照してください。
+
+## インタープリタの制限
+
+この Wasm インタープリタは、資源が制約された宇宙機環境をサポートするため、WebAssembly 1.0 仕様を超える追加の制約を課します。
+
+制限の完全な一覧については、[IR 仕様](./src/SPEC.md)を参照してください。
+
+これらの制約により、資源が制約された環境で決定論的なメモリ使用と効率的な実行を実現しながら、
+ほとんどの標準 WebAssembly モジュールとの互換性を維持できます。
+
+### Wasm モジュール作成者向けの制限
+
+SpaceWasm はバイトコードを固定幅の IR にコンパイルします。IR は通常、元のバイトコードより大きいため、
+生のモジュールサイズの実用上の上限は、上記の IR コードページ上限（約 8 GiB の IR）によって決まります。
+これは飛行用ハードウェアで想定されるどのモジュールよりもはるかに大きく、実際の制約要因は、
+[ストリーミング](#ストリーミング)デコーダーに設定されるピークメモリです。この値は地上で `spacewasm-check` を使用し、モジュールごとに測定されます。
+
+> [!NOTE]
+> `spacewasm-check` はまだ開発されていません。`spacewasm-std` に同様のツールがあります。
+
+Wasm モジュールの開発者に関係する可能性のある制限をいくつか示します。
+
+| 制限                 | 値                  | 備考                                                                                                                                                                                                                                                      |
+| -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wasm ページサイズ    | 64 KiB / 1 B        | [Custom-Page-Sizes 提案](https://github.com/WebAssembly/custom-page-sizes)をサポート                                                                                                                                                                      |
+| 線形メモリページ     | 4 GiB               | Wasm 1.0 仕様に準拠します。これより多くのページを宣言する（または `max` をこれより大きくする）モジュールは拒否されます。組み込み側で必ず制限されますが、その内容はインタープリタの配備方法に依存します。                                                     |
+| IR コード            | 8 GiB               | 生のバイトコードではなく、コンパイル済み IR の値です。この制限はストア内のすべてのモジュールにまたがります。`spacewasm-std` は IR／バイトコード比を「compilation ratio」として表示します。この比率は命令の種類によって異なるため、事前の見積もりは困難です。 |
+| 関数パラメータ       | 255 個の 32 ビットワード    | 関数ごと。                                                                                                                                                                                                                                        |
+| ローカル変数         | 65,535 個の 32 ビットワード | 関数ごと。                                                                                                                                                                                                                                        |
+
+## ベンチマーク
+
+SpaceWasm は Coremark ベンチマークでテストし、性能の回帰を追跡しています。
+詳細については [coremark](crates/spacewasm_std/benches)を参照してください。
+
+## テスト
+
+### ユニットテストと統合テスト
+
+```bash
+cargo test
+```
+
+ユニットテストは、SpaceWasm 独自の `alloc` 使用法に伴って提供される `unsafe` コンテナ抽象化の回帰を検査します。
+また、WAST 全体を実行せずにすべての Wasm 命令を対象とする簡単なユニットテストもあります。
+
+統合テストには Wasm 1.0 MVP テストスイートの仕様テストを使用しています。
+このテスト群は https://github.com/WasmEdge/wasmedge-spectest から選定されたものです。
+これらのテストは、Wasm インタープリタが仕様に準拠していることを検証します。
+
+### ファジング
+
+SpaceWasm には、libfuzzer と
+[wasm-smith](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith) を使用した包括的なファジング基盤が含まれています。
+
+```bash
+# Run fuzzer
+make fuzz
+
+# Analyze crashes with execution traces
+make trace CRASH=fuzz/artifacts/no_traps/crash-xxx
+```
+
+## 機能サポートマトリクス
+
+次の表は、実装済みおよび実装予定の WebAssembly 提案と、対応する追跡 Issue または実装 PR へのリンクを示します。
+
+| 機能                                                                                                         | 状態                                                   |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| [Wasm MVP](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/)                                             | すべてのバージョン                                     |
+| [可変グローバル](https://github.com/WebAssembly/mutable-global)                                              | すべてのバージョン                                     |
+| [カスタムページサイズ](https://github.com/WebAssembly/custom-page-sizes)                                     | [≥0.2.0](https://github.com/nasa/spacewasm/pull/84)    |
+| [バルクメモリ操作](https://github.com/WebAssembly/bulk-memory-operations)                                    | [予定](https://github.com/nasa/spacewasm/issues/54)    |
+| [符号拡張演算子](https://github.com/WebAssembly/sign-extension-ops)                                          | [予定](https://github.com/nasa/spacewasm/issues/55)    |
+| [非トラップ浮動小数点数から整数への変換](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) | [予定](https://github.com/nasa/spacewasm/issues/56)    |
+| [マルチバリュー](https://github.com/WebAssembly/multi-value)                                                 | 検討中                                                 |
+| [マルチメモリ](https://github.com/WebAssembly/multi-memory)                                                  | 検討中                                                 |
+
+現在、その他の提案はいずれも実装、計画、検討されていません。
+
+## クレジットと謝辞
+
+このプロジェクトの一部は、次のオープンソースプロジェクトを基にしています。
+
+- [rust-lang/rust](https://github.com/rust-lang/rust)：MIT OR Apache License 2.0 のデュアルライセンス。
+- [DLR-FT/wasm-interpreter](https://github.com/DLR-FT/wasm-interpreter)：Apache License 2.0。
+- [Wasmtime](https://github.com/bytecodealliance/wasmtime)：LLVM 例外条項付き Apache License 2.0。
+- [WABT](https://github.com/webassembly/wabt)：Apache License 2.0。
+- [wasmedge-spectest](https://github.com/WasmEdge/wasmedge-spectest)：MIT ライセンス。
+- [WebAssembly Testsuite](https://github.com/WebAssembly/testsuite)：Apache License 2.0。
+- [Coremark](https://github.com/eembc/coremark)：COREMARK ACCEPTABLE USE AGREEMENT。
+- [Wasm Coremark](https://github.com/wasm3/wasm-coremark)：上流にはライセンスファイルがありません。内包されている CoreMark ペイロードには COREMARK ACCEPTABLE USE AGREEMENT が適用されます。

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="license" /></a>
 </p>
 
+<p align="center">
+  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a>
+</p>
+
 SpaceWasm is an implementation of the [Wasm 1.0](https://webassembly.github.io/spec/versions/core/WebAssembly-1.0.pdf)
 specification meant to interpret Wasm binary on-board spacecraft. It is developed at [NASA JPL](https://www.jpl.nasa.gov).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,209 @@
+<h1 align="center">SpaceWasm</h2>
+
+<p align="center">
+<img src="docs/logo.svg" width="150" height="150">
+</p>
+
+<p align="center">
+  <a href="https://github.com/nasa/spacewasm/actions/workflows/ci.yml"><img src="https://github.com/nasa/spacewasm/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="https://codecov.io/gh/nasa/spacewasm"><img src="https://codecov.io/gh/nasa/spacewasm/graph/badge.svg?token=3EddiLtM36"/></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="license" /></a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> | 简体中文 | <a href="README.ja.md">日本語</a>
+</p>
+
+SpaceWasm 是 [Wasm 1.0](https://webassembly.github.io/spec/versions/core/WebAssembly-1.0.pdf)
+规范的一种实现，用于在航天器上解释 Wasm 二进制文件。它由 [NASA JPL](https://www.jpl.nasa.gov) 开发。
+
+## 理由
+
+1. **指令序列**：航天器的高级活动通常以指令序列的形式编码在嵌入式飞行软件之外。
+这些活动可以包括驾驶火星车及操作其机械臂，也可以包括检查温度范围是否正常。
+过去，不同任务所用序列的形式和功能各不相同，造成实现方案繁杂且零散。
+SpaceWasm 实现了一项行业标准，从而统一这些实现。
+
+2. **沙箱**：由于飞行软件的需求和范围受到严格约束，其开发成本与耗时都很高。验证一项新的飞行软件能力
+通常需要验证它与整个系统的交互。这会延长验证与确认（V&V）周期，并加剧对测试平台资源的争用，使新的自主软件难以
+进入实际飞行环境。WebAssembly 使不受信任或低信任的可执行文件能够进入航天器，
+同时让飞行软件可以限制其访问权限和计算时间，并监控健康与安全状况。
+
+3. **可移植性**：WebAssembly 提供定义明确的接口和沙箱机制，让迁移到其他平台变得简单。
+
+4. **工具生态**：将 WebAssembly 作为标准，可以接入一个拥有丰富工具和研究成果的广泛社区！
+
+## 概述
+
+本软件包含两个主要组件：
+
+1. 解码器/验证器：
+
+   它分[块](#流式处理)读取 Wasm 二进制文件，并将其解码为可执行形式。解码器使用固定
+   大小的内存；在地面端，可使用 `spacewasm-check` 可执行文件测量每个 Wasm 二进制文件的内存用量。
+
+   WebAssembly 会在解码过程中完成验证，无需再次遍历字节码。
+
+2. 解释器：
+
+   一个可在线性内存上运行，并能与[嵌入](#嵌入)方提供的钩子交互的
+   Wasm 解释器。
+
+SpaceWasm 不直接执行 WebAssembly 字节码。Wasm 字节码的设计目标是体积小、结构便于验证，
+但这些特性也会降低其原地执行的速度。在解码 Wasm 指令的过程中，SpaceWasm
+会将字节码转换为另一种中间表示（IR），其中包含更适合解释执行的属性。有关 IR 的更多信息，请参阅
+[规范](src/SPEC.md)。
+
+## 要求
+
+SpaceWasm 的要求源自 [DLR](https://github.com/DLR-FT/wasm-interpreter) 开展的类似工作。
+
+请参阅[要求](./REQUIREMENTS.md)。
+
+## 嵌入
+
+嵌入解释器是指实例化解释器，并为模块所导入的函数提供实现。
+通常，模块导入的函数集合是固定的，应在编译时同时为 Wasm 模块和嵌入方
+指定这些函数。
+
+## 动态分配
+
+SpaceWasm 采用独特的动态内存分配模型。其所有设计选择都源自常见飞行软件标准提出的要求。
+动态分配遵循以下规则：
+
+1. 所有分配都基于离散的固定大小块（称为_页_）进行。这些页不同于 Wasm 的线性内存页。
+2. 释放操作不得先于分配操作。
+3. 页内的子区域不能增长或缩小，其大小应预先固定。
+4. 内存使用必须具有确定性。
+5. 任何分配失败都_不得_导致 panic。
+
+即使使用自定义分配器，Rust 标准[分配](https://doc.rust-lang.org/alloc/)机制也无法满足这些约束。
+因此，SpaceWasm 提供了自己的数据结构，以保证这些属性。你会发现，这些数据结构包含
+项目中唯一使用 Rust `unsafe` 语义的代码。
+
+> [!NOTE]
+> 这些限制仅适用于解释器的实现，_不_适用于解释器所要解释的 Wasm 字节码。
+
+Wasm 线性内存页在动态内存页之外分配。
+
+## 流式处理
+
+对于航天器上的小型系统而言，_峰值_内存用量通常是一项重要约束。许多 Wasm 解释器
+要求以一个连续的数据块向解释器提供整个 Wasm 二进制文件。对于同一片内存区域可复用于不同用途的系统，
+这通常没有问题。但航天器飞行软件通常会为特定用途划分固定的内存区域。因此，要求整个 Wasm
+二进制文件放入单个连续数据块并不可行。
+
+SpaceWasm 经过高度优化，可降低峰值内存用量，并避免流式处理所需的分配完成后再进行释放。
+为此，它对 WebAssembly 规范施加了一些[约束](#解释器限制)。
+
+SpaceWasm 通过流式机制，支持单次遍历完成 Wasm 二进制文件的解码和编译。可以在从文件系统
+读取或请求 Wasm 二进制文件的各个数据块时，将它们提供给解释器。数据流必须同步提供这些数据块。
+
+
+## WASI 0.1 支持
+[`spacewasi`](crates/spacewasi#readme) crate 提供了一个二进制程序，可在沙箱环境中运行遵循 WASI 0.1（`wasip1`）规范的任意 WASM 模块。命令行参数可用于挂载主机目录和环境变量：
+
+```bash
+# compile example from crates/spacewasi/tests/wasm/
+$ clang --target=wasm32-wasip1 -mcpu=mvp hello_universe.c -o hello_universe.wasm
+
+# convert module to MVP compatible file
+$ crates/spacewasi/scripts/wasm2mvp.sh hello_universe.wasm
+
+$ spacewasi hello_universe.wasm
+hello universe!
+```
+
+有关此命令和 WASI 基本编译方式的更多信息，请参阅 [`spacewasi/README.md`](crates/spacewasi/README.md)。
+
+## 解释器限制
+
+为了支持资源受限的航天器环境，此 Wasm 解释器施加了超出 WebAssembly 1.0 规范的额外约束。
+
+有关完整的限制列表，请参阅我们的 [IR 规范](./src/SPEC.md)。
+
+这些约束既能实现确定性的内存使用和资源受限环境中的高效执行，
+又能保持与大多数标准 WebAssembly 模块的兼容性。
+
+### 面向 Wasm 模块制作者的限制
+
+SpaceWasm 会将字节码编译为固定宽度的 IR，而 IR 通常大于原始字节码，因此原始模块大小的
+实际上限受上述 IR 代码页上限（约 8 GiB IR）约束。这远大于飞行硬件上预期使用的任何模块；
+实践中的约束因素是为[流式处理](#流式处理)解码器配置的峰值内存，
+该值会在地面端使用 `spacewasm-check` 按模块测量。
+
+> [!NOTE]
+> `spacewasm-check` 尚未开发。`spacewasm-std` 中提供了类似工具。
+
+以下是几项可能与 Wasm 模块开发者相关的限制。
+
+| 限制                 | 值                  | 说明                                                                                                                                                                                                                                               |
+| -------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wasm 页大小          | 64 KiB / 1 B        | 支持 [Custom-Page-Sizes 提案](https://github.com/WebAssembly/custom-page-sizes)                                                                                                                                                                    |
+| 线性内存页           | 4 GiB               | 遵循 Wasm 1.0 规范。声明更多页数（或将 `max` 设为更大值）的模块会被拒绝。请注意，嵌入方必然会加以限制，但具体限制取决于解释器的部署方式。                                                                                                           |
+| IR 代码              | 8 GiB               | 指编译后的 IR，而不是原始字节码。此限制适用于存储区中的所有模块。`spacewasm-std` 会将 IR/字节码比率打印为“compilation ratio”。由于该比率随所用指令类型而异，因此很难预先估算。                                                                      |
+| 函数参数             | 255 个 32 位字      | 每个函数。                                                                                                                                                                                                                                         |
+| 局部变量             | 65,535 个 32 位字   | 每个函数。                                                                                                                                                                                                                                         |
+
+## 基准测试
+
+SpaceWasm 使用 Coremark 基准测试来追踪性能回归。
+有关更多信息，请参阅 [coremark](crates/spacewasm_std/benches)。
+
+## 测试
+
+### 单元测试与集成测试
+
+```bash
+cargo test
+```
+
+单元测试会检查 SpaceWasm 因独特的 `alloc` 用法而提供的 `unsafe` 容器抽象是否发生回归。
+此外，还有一些简单的单元测试，无需执行完整的 WAST 即可覆盖所有 Wasm 指令。
+
+集成测试使用 Wasm 1.0 MVP 测试套件中的规范测试，
+该套件整理自 https://github.com/WasmEdge/wasmedge-spectest。
+这些测试用于验证 Wasm 解释器是否符合规范。
+
+### 模糊测试
+
+SpaceWasm 包含一套使用 libfuzzer 和
+[wasm-smith](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith) 的完整模糊测试基础设施。
+
+```bash
+# Run fuzzer
+make fuzz
+
+# Analyze crashes with execution traces
+make trace CRASH=fuzz/artifacts/no_traps/crash-xxx
+```
+
+## 功能支持矩阵
+
+下表列出了已实现和计划实现的 WebAssembly 提案，并附有对应跟踪 Issue 或实现 PR 的链接。
+
+| 功能                                                                                                         | 状态                                                   |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| [Wasm MVP](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/)                                             | 所有版本                                               |
+| [可变全局变量](https://github.com/WebAssembly/mutable-global)                                                | 所有版本                                               |
+| [自定义页大小](https://github.com/WebAssembly/custom-page-sizes)                                             | [≥0.2.0](https://github.com/nasa/spacewasm/pull/84)    |
+| [批量内存操作](https://github.com/WebAssembly/bulk-memory-operations)                                        | [计划中](https://github.com/nasa/spacewasm/issues/54)  |
+| [符号扩展运算符](https://github.com/WebAssembly/sign-extension-ops)                                          | [计划中](https://github.com/nasa/spacewasm/issues/55)  |
+| [非陷阱浮点数到整数转换](https://github.com/WebAssembly/nontrapping-float-to-int-conversions)                 | [计划中](https://github.com/nasa/spacewasm/issues/56)  |
+| [多值](https://github.com/WebAssembly/multi-value)                                                           | 正在考虑                                               |
+| [多内存](https://github.com/WebAssembly/multi-memory)                                                        | 正在考虑                                               |
+
+目前，所有其他提案都尚未实现、规划或考虑。
+
+## 项目来源与致谢
+
+本项目的部分内容改编自以下开源项目：
+
+- [rust-lang/rust](https://github.com/rust-lang/rust)，采用 MIT OR Apache License 2.0 双许可证。
+- [DLR-FT/wasm-interpreter](https://github.com/DLR-FT/wasm-interpreter)，采用 Apache License 2.0。
+- [Wasmtime](https://github.com/bytecodealliance/wasmtime)，采用带 LLVM 例外条款的 Apache License 2.0。
+- [WABT](https://github.com/webassembly/wabt)，采用 Apache License 2.0。
+- [wasmedge-spectest](https://github.com/WasmEdge/wasmedge-spectest)，采用 MIT 许可证。
+- [WebAssembly Testsuite](https://github.com/WebAssembly/testsuite)，采用 Apache License 2.0。
+- [Coremark](https://github.com/eembc/coremark)，采用 COREMARK ACCEPTABLE USE AGREEMENT。
+- [Wasm Coremark](https://github.com/wasm3/wasm-coremark)，上游未提供许可证文件；其封装的 CoreMark 内容受 COREMARK ACCEPTABLE USE AGREEMENT 约束。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese translations of the root README and language links.

Validation:
- Preserved headings, tables, code blocks, technical tokens, and link targets.
- Verified all relative links and ran `git diff --check`.

AI disclosure: ChatGPT assisted with documentation translation in `README.zh-CN.md` and `README.ja.md`. I reviewed and edited the full translations against `README.md` and verified the preserved Markdown structure, code, and links.