### PR TITLE
Avoid pointless Box allocation in C API

### DIFF
--- a/crates/spacewasm_c_api/cbindgen.toml
+++ b/crates/spacewasm_c_api/cbindgen.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [export.rename]
-"SpacewasmAllocator" = "spacewasm_allocator_t"
+"CAllocator" = "spacewasm_allocator_t"
 "SpacewasmCaller" = "spacewasm_caller_t"
 "CEngine" = "spacewasm_t"
 "HostModule" = "spacewasm_host_module_t"

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -318,18 +318,19 @@ typedef int32_t spacewasm_trap_t;
 #endif // __cplusplus
 
 /*
+ The three C callbacks (unwrapped) plus their shared user data, adapting a C
+ allocator to [`WasmMemoryAllocator`]. The callbacks receive `(size, align)`
+ pairs rather than a `Layout`, since C has no equivalent type.
+ */
+typedef struct spacewasm_allocator_t spacewasm_allocator_t;
+
+/*
  Handle holding the SpaceWasm engine and compiled IR code.
  This handle is used for holding and executing the SpaceWasm interpreter.
  */
 typedef struct spacewasm_t spacewasm_t;
 
 typedef struct spacewasm_host_module_t spacewasm_host_module_t;
-
-/*
- Opaque guest linear-memory allocator handle (`spacewasm_allocator_t`), owning
- a reference-counted [`WasmMemoryAllocator`] built from C callbacks.
- */
-typedef struct spacewasm_allocator_t spacewasm_allocator_t;
 
 /*
  Allocate `size` bytes aligned to `align`. Return NULL on failure.

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -318,9 +318,11 @@ typedef int32_t spacewasm_trap_t;
 #endif // __cplusplus
 
 /*
- The three C callbacks (unwrapped) plus their shared user data, adapting a C
- allocator to [`WasmMemoryAllocator`]. The callbacks receive `(size, align)`
- pairs rather than a `Layout`, since C has no equivalent type.
+ A struct holding the alloc, realloc, dealloc, userdata pointers to adapt
+ the C API to the Rc<dyn WasmMemoryAllocator> API.
+
+ This struct is reference counted and deallocated once all modules using this allocator
+ are dropped.
  */
 typedef struct spacewasm_allocator_t spacewasm_allocator_t;
 

--- a/crates/spacewasm_c_api/src/alloc.rs
+++ b/crates/spacewasm_c_api/src/alloc.rs
@@ -4,7 +4,7 @@ use core::alloc::Layout;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
-use spacewasm::{AllocError, Box, GlobalAllocator, Rc, WasmMemoryAllocator};
+use spacewasm::{AllocError, Rc, WasmMemoryAllocator};
 
 /// Allocate `size` bytes aligned to `align`. Return NULL on failure.
 pub type spacewasm_alloc_fn_t =
@@ -29,7 +29,7 @@ pub type spacewasm_dealloc_fn_t =
 /// The three C callbacks (unwrapped) plus their shared user data, adapting a C
 /// allocator to [`WasmMemoryAllocator`]. The callbacks receive `(size, align)`
 /// pairs rather than a `Layout`, since C has no equivalent type.
-struct CAllocator {
+pub struct CAllocator {
     alloc: unsafe extern "C" fn(*mut c_void, usize, usize) -> *mut u8,
     realloc: unsafe extern "C" fn(*mut c_void, *mut u8, usize, usize, usize) -> *mut u8,
     dealloc: unsafe extern "C" fn(*mut c_void, *mut u8, usize, usize),
@@ -72,10 +72,6 @@ impl WasmMemoryAllocator for CAllocator {
     }
 }
 
-/// Opaque guest linear-memory allocator handle (`spacewasm_allocator_t`), owning
-/// a reference-counted [`WasmMemoryAllocator`] built from C callbacks.
-pub struct SpacewasmAllocator(Rc<CAllocator>);
-
 /// Build an allocator handle from three C callbacks. Returns null if any
 /// callback is null or the handle allocation fails.
 pub fn allocator_new(
@@ -83,7 +79,7 @@ pub fn allocator_new(
     realloc: spacewasm_realloc_fn_t,
     dealloc: spacewasm_dealloc_fn_t,
     userdata: *mut c_void,
-) -> *mut SpacewasmAllocator {
+) -> *mut CAllocator {
     let (Some(alloc), Some(realloc), Some(dealloc)) = (alloc, realloc, dealloc) else {
         return unsafe { core::mem::transmute(core::ptr::null_mut::<CAllocator>()) };
     };
@@ -106,21 +102,20 @@ pub fn allocator_new(
 ///
 /// # Safety
 /// `handle` must be null or a live pointer from [`allocator_new`].
-pub unsafe fn allocator_clone_rc(
-    handle: *const SpacewasmAllocator,
-) -> Option<Rc<dyn WasmMemoryAllocator>> {
-    let handle = unsafe { handle.as_ref() }?;
-    Some(handle.0.clone().into_wasm_memory_allocator())
+pub unsafe fn allocator_clone_rc(handle: *const CAllocator) -> Option<Rc<dyn WasmMemoryAllocator>> {
+    let handle: Rc<CAllocator> = unsafe { core::mem::transmute(handle.as_ref()?) };
+    Some(handle.clone().into_wasm_memory_allocator())
 }
 
 /// Destroy an allocator handle. No-op on null.
 ///
 /// # Safety
 /// `handle` must be a live pointer from [`allocator_new`], not already destroyed.
-pub unsafe fn allocator_destroy(handle: *mut SpacewasmAllocator) {
+pub unsafe fn allocator_destroy(handle: *mut CAllocator) {
     if handle.is_null() {
         return;
     }
-    // Reclaim ownership and drop, releasing this handle's reference.
-    let _ = unsafe { Box::from_raw(GlobalAllocator, handle) };
+
+    let handle: Rc<CAllocator> = unsafe { core::mem::transmute(handle) };
+    drop(handle);
 }

--- a/crates/spacewasm_c_api/src/alloc.rs
+++ b/crates/spacewasm_c_api/src/alloc.rs
@@ -26,9 +26,11 @@ pub type spacewasm_realloc_fn_t = Option<
 pub type spacewasm_dealloc_fn_t =
     Option<unsafe extern "C" fn(userdata: *mut c_void, ptr: *mut u8, size: usize, align: usize)>;
 
-/// The three C callbacks (unwrapped) plus their shared user data, adapting a C
-/// allocator to [`WasmMemoryAllocator`]. The callbacks receive `(size, align)`
-/// pairs rather than a `Layout`, since C has no equivalent type.
+/// A struct holding the alloc, realloc, dealloc, userdata pointers to adapt
+/// the C API to the Rc<dyn WasmMemoryAllocator> API.
+///
+/// This struct is reference counted and deallocated once all modules using this allocator
+/// are dropped.
 pub struct CAllocator {
     alloc: unsafe extern "C" fn(*mut c_void, usize, usize) -> *mut u8,
     realloc: unsafe extern "C" fn(*mut c_void, *mut u8, usize, usize, usize) -> *mut u8,

--- a/crates/spacewasm_c_api/src/alloc.rs
+++ b/crates/spacewasm_c_api/src/alloc.rs
@@ -74,9 +74,7 @@ impl WasmMemoryAllocator for CAllocator {
 
 /// Opaque guest linear-memory allocator handle (`spacewasm_allocator_t`), owning
 /// a reference-counted [`WasmMemoryAllocator`] built from C callbacks.
-pub struct SpacewasmAllocator {
-    inner: Rc<dyn WasmMemoryAllocator>,
-}
+pub struct SpacewasmAllocator(Rc<CAllocator>);
 
 /// Build an allocator handle from three C callbacks. Returns null if any
 /// callback is null or the handle allocation fails.
@@ -87,7 +85,7 @@ pub fn allocator_new(
     userdata: *mut c_void,
 ) -> *mut SpacewasmAllocator {
     let (Some(alloc), Some(realloc), Some(dealloc)) = (alloc, realloc, dealloc) else {
-        return core::ptr::null_mut();
+        return unsafe { core::mem::transmute(core::ptr::null_mut::<CAllocator>()) };
     };
 
     let c = CAllocator {
@@ -98,13 +96,8 @@ pub fn allocator_new(
     };
 
     match Rc::new(c) {
-        Ok(rc) => {
-            let inner = rc.into_wasm_memory_allocator();
-            Box::new(SpacewasmAllocator { inner })
-                .map(|b| Box::leak(b) as *mut SpacewasmAllocator)
-                .unwrap_or(core::ptr::null_mut())
-        }
-        Err(_) => core::ptr::null_mut(),
+        Ok(rc) => unsafe { core::mem::transmute(rc) },
+        Err(_) => unsafe { core::mem::transmute(core::ptr::null_mut::<CAllocator>()) },
     }
 }
 
@@ -117,7 +110,7 @@ pub unsafe fn allocator_clone_rc(
     handle: *const SpacewasmAllocator,
 ) -> Option<Rc<dyn WasmMemoryAllocator>> {
     let handle = unsafe { handle.as_ref() }?;
-    Some(handle.inner.clone())
+    Some(handle.0.clone().into_wasm_memory_allocator())
 }
 
 /// Destroy an allocator handle. No-op on null.

--- a/crates/spacewasm_c_api/src/alloc.rs
+++ b/crates/spacewasm_c_api/src/alloc.rs
@@ -103,8 +103,15 @@ pub fn allocator_new(
 /// # Safety
 /// `handle` must be null or a live pointer from [`allocator_new`].
 pub unsafe fn allocator_clone_rc(handle: *const CAllocator) -> Option<Rc<dyn WasmMemoryAllocator>> {
-    let handle: Rc<CAllocator> = unsafe { core::mem::transmute(handle.as_ref()?) };
-    Some(handle.clone().into_wasm_memory_allocator())
+    if handle.is_null() {
+        return None;
+    }
+
+    // Transmut to manually drop since `CAllocator` is really a &Rc<Allocator> but the lifetime is not
+    // defined from the C side.
+    let handle: core::mem::ManuallyDrop<Rc<CAllocator>> =
+        unsafe { core::mem::transmute::<*const CAllocator, _>(handle) };
+    Some(Rc::clone(&handle).into_wasm_memory_allocator())
 }
 
 /// Destroy an allocator handle. No-op on null.

--- a/crates/spacewasm_c_api/src/alloc.rs
+++ b/crates/spacewasm_c_api/src/alloc.rs
@@ -81,7 +81,7 @@ pub fn allocator_new(
     userdata: *mut c_void,
 ) -> *mut CAllocator {
     let (Some(alloc), Some(realloc), Some(dealloc)) = (alloc, realloc, dealloc) else {
-        return unsafe { core::mem::transmute(core::ptr::null_mut::<CAllocator>()) };
+        return core::ptr::null_mut::<CAllocator>();
     };
 
     let c = CAllocator {
@@ -92,8 +92,8 @@ pub fn allocator_new(
     };
 
     match Rc::new(c) {
-        Ok(rc) => unsafe { core::mem::transmute(rc) },
-        Err(_) => unsafe { core::mem::transmute(core::ptr::null_mut::<CAllocator>()) },
+        Ok(rc) => unsafe { core::mem::transmute::<spacewasm::Rc<CAllocator>, *mut CAllocator>(rc) },
+        Err(_) => core::ptr::null_mut::<CAllocator>(),
     }
 }
 

--- a/crates/spacewasm_c_api/src/capi.rs
+++ b/crates/spacewasm_c_api/src/capi.rs
@@ -9,9 +9,8 @@ use spacewasm::{
 };
 
 use crate::SpacewasmCaller;
-use crate::alloc::{
-    self, SpacewasmAllocator, spacewasm_alloc_fn_t, spacewasm_dealloc_fn_t, spacewasm_realloc_fn_t,
-};
+use crate::alloc::CAllocator;
+use crate::alloc::{self, spacewasm_alloc_fn_t, spacewasm_dealloc_fn_t, spacewasm_realloc_fn_t};
 use crate::config::{MAX_CONTROL_FRAMES, MAX_STACK_DEPTH};
 use crate::host;
 use crate::host::CHostFunction;
@@ -88,7 +87,7 @@ pub extern "C" fn spacewasm_allocator_new(
     realloc: spacewasm_realloc_fn_t,
     dealloc: spacewasm_dealloc_fn_t,
     userdata: *mut c_void,
-) -> *mut SpacewasmAllocator {
+) -> *mut CAllocator {
     alloc::allocator_new(alloc, realloc, dealloc, userdata)
 }
 
@@ -100,7 +99,7 @@ pub extern "C" fn spacewasm_allocator_new(
 /// `allocator` must be a live handle from [`spacewasm_allocator_new`], not
 /// already destroyed.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn spacewasm_allocator_destroy(allocator: *mut SpacewasmAllocator) {
+pub unsafe extern "C" fn spacewasm_allocator_destroy(allocator: *mut CAllocator) {
     unsafe { alloc::allocator_destroy(allocator) }
 }
 
@@ -253,7 +252,7 @@ pub unsafe extern "C" fn spacewasm_load_module(
     name: *const c_char,
     read: spacewasm_read_fn_t,
     read_userdata: *mut c_void,
-    allocator: *mut SpacewasmAllocator,
+    allocator: *mut CAllocator,
     out_module_idx: *mut u32,
 ) -> spacewasm_status_t {
     // SAFETY: `allocator` is null or a live handle per the contract.

--- a/crates/spacewasm_c_api/src/lib.rs
+++ b/crates/spacewasm_c_api/src/lib.rs
@@ -24,9 +24,7 @@ pub mod global_alloc;
 mod tests;
 
 // Re-exports for C callers and downstream Rust consumers.
-pub use alloc::{
-    SpacewasmAllocator, spacewasm_alloc_fn_t, spacewasm_dealloc_fn_t, spacewasm_realloc_fn_t,
-};
+pub use alloc::{CAllocator, spacewasm_alloc_fn_t, spacewasm_dealloc_fn_t, spacewasm_realloc_fn_t};
 pub use capi::{CEngine, spacewasm_compiler_options_t};
 #[cfg(feature = "provide-global-allocator")]
 pub use global_alloc::{

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -7,7 +7,7 @@ use core::ffi::c_void;
 use std::alloc::{Layout, alloc, dealloc, realloc};
 use std::sync::Mutex;
 
-use crate::SpacewasmAllocator;
+use crate::CAllocator;
 use crate::capi::*;
 use crate::host::{SpacewasmCaller, spacewasm_hostcall_result_t};
 use crate::status::{self, spacewasm_run_status_t, spacewasm_status_t, spacewasm_trap_t};
@@ -85,7 +85,7 @@ unsafe extern "C" fn mem_dealloc(_userdata: *mut c_void, ptr: *mut u8, size: usi
     }
 }
 
-fn new_guest_allocator() -> *mut SpacewasmAllocator {
+fn new_guest_allocator() -> *mut CAllocator {
     spacewasm_allocator_new(
         Some(mem_alloc),
         Some(mem_realloc),
@@ -242,7 +242,7 @@ fn new_store(stack_size: usize, max_modules: u32, max_code_pages: u32) -> *mut C
 /// Stream one module onto an existing store in `step`-byte chunks, then run its
 /// start function if it declares one. Returns the module index on success.
 fn load_module_onto(
-    alloc: *mut SpacewasmAllocator,
+    alloc: *mut CAllocator,
     store: *mut CEngine,
     name: &core::ffi::CStr,
     data: &'static [u8],


### PR DESCRIPTION
We were wrapping a `Rc<dyn WasmAllocator>` in a `Box<>` in the C API which is inefficient and incorrect for a couple of reasons:

1. Every clone/destroy of the allocator meant a small alloc/dealloc which broke our invariants.
2. We don't want to store `dyn WasmAllocator` for the C version since we know there is exactly 1 allocator so we can just use `*CAllocator`.