### PR TITLE
C api host return none

### DIFF
--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -143,17 +143,21 @@ enum spacewasm_hostcall_result_t
 #endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
     /*
+     Continue, do not return a value
+     */
+    SPACEWASM_CONTINUE_NONE = 0,
+    /*
      Continue; populate `out_result` if the function has a result type.
      */
-    SPACEWASM_CONTINUE = 0,
+    SPACEWASM_CONTINUE_SOME = 1,
     /*
      Trap the interpreter.
      */
-    SPACEWASM_TRAP = 1,
+    SPACEWASM_TRAP = 2,
     /*
      Pause the interpreter (cooperative yield).
      */
-    SPACEWASM_PAUSE = 2,
+    SPACEWASM_PAUSE = 3,
 };
 #ifndef __cplusplus
 #if __STDC_VERSION__ >= 202311L

--- a/crates/spacewasm_c_api/src/host.rs
+++ b/crates/spacewasm_c_api/src/host.rs
@@ -46,12 +46,14 @@ pub type spacewasm_host_fn_t = Option<
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum spacewasm_hostcall_result_t {
+    /// Continue, do not return a value
+    SPACEWASM_CONTINUE_NONE = 0,
     /// Continue; populate `out_result` if the function has a result type.
-    SPACEWASM_CONTINUE = 0,
+    SPACEWASM_CONTINUE_SOME = 1,
     /// Trap the interpreter.
-    SPACEWASM_TRAP = 1,
+    SPACEWASM_TRAP = 2,
     /// Pause the interpreter (cooperative yield).
-    SPACEWASM_PAUSE = 2,
+    SPACEWASM_PAUSE = 3,
 }
 
 /// A C function pointer plus its (embedder-owned) user data, stored inside the
@@ -119,7 +121,8 @@ impl CHostFunction {
         };
 
         match outcome {
-            spacewasm_hostcall_result_t::SPACEWASM_CONTINUE => {
+            spacewasm_hostcall_result_t::SPACEWASM_CONTINUE_NONE => ControlFlow::Continue(None),
+            spacewasm_hostcall_result_t::SPACEWASM_CONTINUE_SOME => {
                 ControlFlow::Continue(Some(out_result.to_value()))
             }
             spacewasm_hostcall_result_t::SPACEWASM_TRAP => {

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -171,6 +171,27 @@ static HOST_WASM: &[u8] = &[
     0x00, 0x21, 0x01, 0x41, 0x00, 0x20, 0x01, 0x36, 0x02, 0x00, 0x20, 0x01, 0x0b,
 ];
 
+/// A module importing a void `env.sink` (`(param i32)`, no result) and a `run`
+/// function that keeps a sentinel on the stack across the call, then returns
+/// `param + 1`. If the host call spuriously pushed a value, the sentinel would
+/// be corrupted and the result would be wrong.
+///
+/// ```wat
+/// (module
+///   (import "env" "sink" (func $sink (param i32)))
+///   (func (export "run") (param i32) (result i32)
+///     local.get 0 local.get 0 call $sink i32.const 1 i32.add))
+/// ```
+#[rustfmt::skip]
+static VOID_HOST_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02, 0x60,
+    0x01, 0x7f, 0x00, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x02, 0x0c, 0x01, 0x03,
+    0x65, 0x6e, 0x76, 0x04, 0x73, 0x69, 0x6e, 0x6b, 0x00, 0x00, 0x03, 0x02,
+    0x01, 0x01, 0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01, 0x0a,
+    0x0d, 0x01, 0x0b, 0x00, 0x20, 0x00, 0x20, 0x00, 0x10, 0x00, 0x41, 0x01,
+    0x6a, 0x0b,
+];
+
 /// `(module (func (export "boom") (result i32) unreachable))` — traps on call.
 #[rustfmt::skip]
 static TRAP_WASM: &[u8] = &[
@@ -555,6 +576,87 @@ fn host_function_and_memory() {
         "result"
     );
     assert_eq!(unsafe { out.u.i32_ }, 42, "add_one(41)");
+
+    unsafe {
+        spacewasm_destroy(store);
+        spacewasm_allocator_destroy(alloc);
+    }
+}
+
+#[test]
+fn void_host_function_pushes_no_value() {
+    let _guard = ALLOC_LOCK.lock().unwrap();
+    ensure_global_allocator();
+
+    let mut host = core::mem::MaybeUninit::<spacewasm_host_t>::uninit();
+    assert_eq!(
+        unsafe { spacewasm_host_new(1, host.as_mut_ptr()) },
+        status::SPACEWASM_OK,
+        "host_new"
+    );
+
+    let mut hmod = 0u32;
+    unsafe {
+        assert_eq!(
+            spacewasm_add_host_module(host.as_mut_ptr(), c"env".as_ptr(), 1, 0, &mut hmod),
+            status::SPACEWASM_OK,
+            "add_host_module"
+        );
+        // `sink` takes one i32 and returns nothing (empty result signature).
+        assert_eq!(
+            spacewasm_add_host_function(
+                host.as_mut_ptr(),
+                hmod,
+                c"sink".as_ptr(),
+                c"i".as_ptr(),
+                c"".as_ptr(),
+                Some(sink),
+                core::ptr::null_mut(),
+            ),
+            status::SPACEWASM_OK,
+            "add_host_function"
+        );
+    }
+
+    let mut store: *mut CEngine = core::ptr::null_mut();
+    assert_eq!(
+        unsafe { spacewasm_new(host.as_mut_ptr(), 1024, 1, opts(256), &mut store) },
+        status::SPACEWASM_OK,
+        "store_new"
+    );
+
+    let alloc = new_guest_allocator();
+    let idx = load_module_onto(alloc, store, c"main", VOID_HOST_WASM, 0).expect("load void module");
+
+    let mut func = 0u32;
+    assert_eq!(
+        unsafe { spacewasm_find_export_func(store, idx, c"run".as_ptr(), &mut func) },
+        status::SPACEWASM_OK,
+        "find run"
+    );
+
+    // `run(41)` keeps 41 on the stack across the void `sink` call, then adds 1.
+    // If the host call had spuriously pushed a value, the trailing `i32.add`
+    // would consume it and produce a corrupt (or trapping) result.
+    let params = [i32_val(41)];
+    assert_eq!(
+        unsafe { spacewasm_invoke(store, idx, func, params.as_ptr(), params.len()) },
+        status::SPACEWASM_OK,
+        "invoke"
+    );
+    let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
+    assert_eq!(
+        run_to_completion(store, &mut trap),
+        spacewasm_run_status_t::SPACEWASM_RUN_FINISHED,
+        "run (trap={trap:?})"
+    );
+    let mut out = i32_val(0);
+    assert_eq!(
+        unsafe { spacewasm_get_result(store, spacewasm_valtype_t::SPACEWASM_I32, &mut out) },
+        status::SPACEWASM_OK,
+        "result"
+    );
+    assert_eq!(unsafe { out.u.i32_ }, 42, "void host call must not push a value");
 
     unsafe {
         spacewasm_destroy(store);
@@ -1372,6 +1474,25 @@ fn run_slices_out_of_fuel_then_resumes() {
         spacewasm_destroy(store);
         spacewasm_allocator_destroy(alloc);
     }
+}
+
+/// Host implementation of `env.sink`: a void host function (no result type). It
+/// asserts it received exactly one argument and returns `SPACEWASM_CONTINUE_NONE`
+/// *while still writing to `out`*, to prove the interpreter honours the "no
+/// value" outcome and does not push the stale `out` onto the Wasm stack.
+unsafe extern "C" fn sink(
+    _caller: *mut SpacewasmCaller,
+    _userdata: *mut c_void,
+    _params: *const spacewasm_value_t,
+    n: usize,
+    out: *mut spacewasm_value_t,
+) -> spacewasm_hostcall_result_t {
+    if n != 1 {
+        return spacewasm_hostcall_result_t::SPACEWASM_TRAP;
+    }
+    // Deliberately scribble a bogus result; CONTINUE_NONE must ignore it.
+    unsafe { *out = i32_val(0x7fff_ffff) };
+    spacewasm_hostcall_result_t::SPACEWASM_CONTINUE_NONE
 }
 
 /// Host callback that pauses execution without returning a value.

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -354,7 +354,7 @@ unsafe extern "C" fn add_one(
     }
     let arg = unsafe { (*params).u.i32_ };
     unsafe { *out = i32_val(arg + 1) };
-    spacewasm_hostcall_result_t::SPACEWASM_CONTINUE
+    spacewasm_hostcall_result_t::SPACEWASM_CONTINUE_SOME
 }
 
 // ---- test cases (one per C `test_*` function) -------------------------------
@@ -1455,7 +1455,7 @@ unsafe extern "C" fn mem_probe(
 
     let arg = unsafe { (*params).u.i32_ };
     unsafe { *out = i32_val(arg + 1) };
-    spacewasm_hostcall_result_t::SPACEWASM_CONTINUE
+    spacewasm_hostcall_result_t::SPACEWASM_CONTINUE_SOME
 }
 
 #[test]

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -656,7 +656,11 @@ fn void_host_function_pushes_no_value() {
         status::SPACEWASM_OK,
         "result"
     );
-    assert_eq!(unsafe { out.u.i32_ }, 42, "void host call must not push a value");
+    assert_eq!(
+        unsafe { out.u.i32_ },
+        42,
+        "void host call must not push a value"
+    );
 
     unsafe {
         spacewasm_destroy(store);

--- a/crates/spacewasm_c_example/examples/ctest_suite.c
+++ b/crates/spacewasm_c_example/examples/ctest_suite.c
@@ -349,7 +349,7 @@ static spacewasm_hostcall_result_t add_one(spacewasm_caller_t* caller, void* use
         return SPACEWASM_TRAP;
     }
     *out = i32_val(params[0].u.i32_ + 1);
-    return SPACEWASM_CONTINUE;
+    return SPACEWASM_CONTINUE_SOME;
 }
 
 static int test_host_function_and_memory(void) {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -230,7 +230,7 @@ impl<'a, const MAX_CONTROL_FRAMES: usize, const MAX_STACK_DEPTH: usize> WasmVisi
                     let _ = state.pop_stack(p)?;
                 }
 
-                for r in f.returns().iter().rev() {
+                if let Some(r) = f.returns().0 {
                     state.push_stack(r)?;
                 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -312,7 +312,7 @@ pub const HOST_FUNCTION_NAME_CAP: usize = 31;
 pub struct HostFunction {
     name: HostName<HOST_FUNCTION_NAME_CAP>,
     params: HostValList,
-    returns: HostValList,
+    returns: ResultType,
     f: HostFunctionFn,
 }
 
@@ -321,7 +321,7 @@ impl Debug for HostFunction {
         f.debug_struct("HostFunction")
             .field("name", &self.name)
             .field("params", &self.params.as_slice())
-            .field("returns", &self.returns.as_slice())
+            .field("returns", &self.returns)
             .finish()
     }
 }
@@ -356,7 +356,7 @@ impl HostFunction {
         f: impl Fn(&mut Engine, &[Value]) -> HostFunctionResult + 'static,
     ) -> Self {
         HostFunction::try_new(name.into(), params, returns, f)
-            .expect("host function signature too large")
+            .expect("host function signature too large or invalid return value")
     }
 
     /// Fallibly construct a host function, returning an error if the parameter
@@ -373,15 +373,19 @@ impl HostFunction {
             return Err(HostValListError);
         }
 
-        let rs = returns.iter().fold(0, |n, i| n + i.size()) / 4;
-        if rs > 0xFFFF {
-            return Err(HostValListError);
+        let mut rs: Option<ValType> = None;
+        for r in returns.iter() {
+            if rs.is_some() {
+                return Err(HostValListError);
+            }
+
+            rs = Some(r);
         }
 
         Ok(HostFunction {
             name,
             params,
-            returns,
+            returns: ResultType(rs),
             f: Box::new(f).unwrap().into_host_function_dyn(),
         })
     }
@@ -390,7 +394,7 @@ impl HostFunction {
         self.params
     }
 
-    pub fn returns(&self) -> HostValList {
+    pub fn returns(&self) -> ResultType {
         self.returns
     }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -38,8 +38,13 @@ impl Store {
                 for (fi, f) in module.functions.iter().enumerate() {
                     if f.name() == name {
                         // Validate the function signature
+                        let return_vals: &[ValType] = match f.returns().0 {
+                            Some(v) => &[v],
+                            None => &[],
+                        };
+
                         return if f.params() == expected_ty.params[..]
-                            && f.returns() == expected_ty.returns[..]
+                            && return_vals != &expected_ty.returns[..]
                         {
                             Ok(Import::HostFunc {
                                 module: HostModuleRef::new(mi),
@@ -102,8 +107,13 @@ impl Store {
                                     let hm = &self.host_modules()[module.0 as usize];
                                     let f = &hm.functions[index as usize];
 
+                                    let return_vals: &[ValType] = match f.returns().0 {
+                                        Some(v) => &[v],
+                                        None => &[],
+                                    };
+
                                     if f.params() == expected_ty.params[..]
-                                        && f.returns() == expected_ty.returns[..]
+                                        && return_vals == &expected_ty.returns[..]
                                     {
                                         Ok(Import::HostFunc { module, index })
                                     } else {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -44,7 +44,7 @@ impl Store {
                         };
 
                         return if f.params() == expected_ty.params[..]
-                            && return_vals != &expected_ty.returns[..]
+                            && return_vals == &expected_ty.returns[..]
                         {
                             Ok(Import::HostFunc {
                                 module: HostModuleRef::new(mi),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1418,23 +1418,28 @@ impl IrVisitor for Interpreter {
         let f = &state.store.host_modules_mut()[module.0 as usize].functions[x as usize];
         match r {
             ControlFlow::Continue(v) => {
-                match v {
-                    None => {}
-                    Some(Value::I32(i)) => {
+                match (v, f.returns().0) {
+                    (None, None) => {}
+                    (Some(Value::I32(i)), Some(ValType::I32)) => {
                         state.stack.write_u32(state.sp, i as u32);
                         state.sp += 1;
                     }
-                    Some(Value::I64(i)) => {
+                    (Some(Value::I64(i)), Some(ValType::I64)) => {
                         state.stack.write_u64(state.sp, i as u64);
                         state.sp += 2;
                     }
-                    Some(Value::F32(f)) => {
+                    (Some(Value::F32(f)), Some(ValType::F32)) => {
                         state.stack.write_f32(state.sp, f);
                         state.sp += 1;
                     }
-                    Some(Value::F64(f)) => {
+                    (Some(Value::F64(f)), Some(ValType::F64)) => {
                         state.stack.write_f64(state.sp, f);
                         state.sp += 2;
+                    }
+                    (got, expected) => {
+                        panic!(
+                            "host function returned {got:?} while declaration expecting {expected:?}"
+                        )
                     }
                 }
 
@@ -1498,7 +1503,13 @@ impl IrVisitor for Interpreter {
                 // Make sure the type matches our expectations (runtime validation)
                 let m = &state.store.host_modules()[module.0 as usize];
                 let f = &m.functions[*index as usize];
-                if f.params() != f_expected.params[..] || f.returns() != f_expected.returns[..] {
+
+                let return_vals: &[ValType] = match f.returns().0 {
+                    Some(v) => &[v],
+                    None => &[],
+                };
+
+                if f.params() != f_expected.params[..] || return_vals != &f_expected.returns[..] {
                     return Err(InterpreterBreak::Trap(TrapReason::InvalidTableFunctionType));
                 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1446,7 +1446,7 @@ impl IrVisitor for Interpreter {
                 Ok(())
             }
             ControlFlow::Break(HostFunctionBreak::Pause) => {
-                let other = state.host_pause_result.replace(f.returns().into());
+                let other = state.host_pause_result.replace(f.returns());
                 if other.is_some() {
                     panic!("Unexpected paused engine state");
                 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -354,7 +354,7 @@ impl Module {
                     }
                     Ref::Host { module, index } => {
                         let f = &store.host_modules()[module.0 as usize].functions[index as usize];
-                        if !f.params().is_empty() || !f.returns().is_empty() {
+                        if !f.params().is_empty() || !f.returns().0.is_none() {
                             return Err(ValidationError::InvalidStartFunctionSignature);
                         }
                     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -354,7 +354,7 @@ impl Module {
                     }
                     Ref::Host { module, index } => {
                         let f = &store.host_modules()[module.0 as usize].functions[index as usize];
-                        if !f.params().is_empty() || !f.returns().0.is_none() {
+                        if !f.params().is_empty() || f.returns().0.is_some() {
                             return Err(ValidationError::InvalidStartFunctionSignature);
                         }
                     }

--- a/tests/regression/host_func_invalid_should_panic_none.wast
+++ b/tests/regression/host_func_invalid_should_panic_none.wast
@@ -1,0 +1,10 @@
+(module
+  (import "regression" "invalid_should_return_none"
+    (func $invalid_should_return_none))
+
+  (func (export "call") (result i32)
+    (call $invalid_should_return_none) unreachable)
+)
+
+;; This function should cause a panic because the host function is invalid
+(assert_return (invoke "call") (i32.const 0))

--- a/tests/regression/host_func_invalid_should_panic_some.wast
+++ b/tests/regression/host_func_invalid_should_panic_some.wast
@@ -1,0 +1,10 @@
+(module
+  (import "regression" "invalid_should_return_some"
+    (func $invalid_should_return_some (result i32)))
+
+  (func (export "call") (result i32)
+    (call $invalid_should_return_some) unreachable)
+)
+
+;; This function should cause a panic because the host function is invalid
+(assert_return (invoke "call") (i32.const 0))

--- a/tests/regression_integration.rs
+++ b/tests/regression_integration.rs
@@ -88,14 +88,24 @@ pub fn regression_host_module() -> HostModule {
             HostFunction::new("pause_f64", "".into(), "d".into(), |_, _| {
                 ControlFlow::Break(HostFunctionBreak::Pause)
             }),
-            HostFunction::new("invalid_should_return_some", "".into(), "i".into(), |_, _| {
-                // The return value string says it returns an i32 but we are returning void
-                ControlFlow::Continue(None)
-            }),
-            HostFunction::new("invalid_should_return_none", "".into(), "".into(), |_, _| {
-                // The return value string says it returns void but we are returning Some(I32(1))
-                ControlFlow::Continue(Some(Value::I32(1)))
-            }),
+            HostFunction::new(
+                "invalid_should_return_some",
+                "".into(),
+                "i".into(),
+                |_, _| {
+                    // The return value string says it returns an i32 but we are returning void
+                    ControlFlow::Continue(None)
+                },
+            ),
+            HostFunction::new(
+                "invalid_should_return_none",
+                "".into(),
+                "".into(),
+                |_, _| {
+                    // The return value string says it returns void but we are returning Some(I32(1))
+                    ControlFlow::Continue(Some(Value::I32(1)))
+                },
+            ),
         ],
         memory: vec![],
         table: vec![],

--- a/tests/regression_integration.rs
+++ b/tests/regression_integration.rs
@@ -88,6 +88,14 @@ pub fn regression_host_module() -> HostModule {
             HostFunction::new("pause_f64", "".into(), "d".into(), |_, _| {
                 ControlFlow::Break(HostFunctionBreak::Pause)
             }),
+            HostFunction::new("invalid_should_return_some", "".into(), "i".into(), |_, _| {
+                // The return value string says it returns an i32 but we are returning void
+                ControlFlow::Continue(None)
+            }),
+            HostFunction::new("invalid_should_return_none", "".into(), "".into(), |_, _| {
+                // The return value string says it returns void but we are returning Some(I32(1))
+                ControlFlow::Continue(Some(Value::I32(1)))
+            }),
         ],
         memory: vec![],
         table: vec![],
@@ -148,4 +156,16 @@ fn decode_errors() {
 #[test]
 fn pause_resume() {
     run("regression/pause-resume");
+}
+
+#[test]
+#[should_panic = "host function returned Some(I32(1)) while declaration expecting None"]
+fn host_func_invalid_should_panic_none() {
+    run("regression/host_func_invalid_should_panic_none");
+}
+
+#[test]
+#[should_panic = "host function returned None while declaration expecting Some(I32)"]
+fn host_func_invalid_should_panic_some() {
+    run("regression/host_func_invalid_should_panic_some");
 }


### PR DESCRIPTION
This C API was unconditionally returning a value to the value stack even if it should have been void.

I've updated the interpreter to validate host function returns as is already done across a pause/resume. I've also updated the C API to allow returning NONE.