### PR TITLE
Return an error instead of aborting on invalid resume

### DIFF
--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -637,6 +637,8 @@ spacewasm_run_status_t spacewasm_run(struct spacewasm_t *engine,
 /*
  Resume the interpreter from a paused state.
 
+ Returns `SPACEWASM_ERR_WRONG_STATE` if the engine is not paused.
+
  # Safety
  `engine` must be live.
  */
@@ -646,6 +648,9 @@ spacewasm_status_t spacewasm_resume(struct spacewasm_t *engine);
  Resume the interpreter from a paused state.
  This function will also push a value to the interpreter stack
  as the return value of the host function that requested a pause.
+
+ Returns `SPACEWASM_ERR_WRONG_STATE` if the engine is not paused, or if
+ `resume_value` does not match the paused host function's result type.
 
  # Safety
  `engine` must be live.

--- a/crates/spacewasm_c_api/src/capi.rs
+++ b/crates/spacewasm_c_api/src/capi.rs
@@ -569,6 +569,8 @@ pub unsafe extern "C" fn spacewasm_run(
 
 /// Resume the interpreter from a paused state.
 ///
+/// Returns `SPACEWASM_ERR_WRONG_STATE` if the engine is not paused.
+///
 /// # Safety
 /// `engine` must be live.
 #[unsafe(no_mangle)]
@@ -577,13 +579,19 @@ pub unsafe extern "C" fn spacewasm_resume(engine: *mut CEngine) -> spacewasm_sta
         return status::SPACEWASM_ERR_NULL_ARG;
     };
 
-    cengine.engine.resume(None);
-    status::SPACEWASM_OK
+    if cengine.engine.resume(None) {
+        status::SPACEWASM_OK
+    } else {
+        status::SPACEWASM_ERR_WRONG_STATE
+    }
 }
 
 /// Resume the interpreter from a paused state.
 /// This function will also push a value to the interpreter stack
 /// as the return value of the host function that requested a pause.
+///
+/// Returns `SPACEWASM_ERR_WRONG_STATE` if the engine is not paused, or if
+/// `resume_value` does not match the paused host function's result type.
 ///
 /// # Safety
 /// `engine` must be live.
@@ -596,8 +604,11 @@ pub unsafe extern "C" fn spacewasm_resume_value(
         return status::SPACEWASM_ERR_NULL_ARG;
     };
 
-    cengine.engine.resume(Some(resume_value.into()));
-    status::SPACEWASM_OK
+    if cengine.engine.resume(Some(resume_value.into())) {
+        status::SPACEWASM_OK
+    } else {
+        status::SPACEWASM_ERR_WRONG_STATE
+    }
 }
 
 /// Fetch the result of the last completed call, coerced to `expected`, into

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -669,6 +669,124 @@ fn void_host_function_pushes_no_value() {
 }
 
 #[test]
+fn resume_without_pause_returns_wrong_state() {
+    let _guard = ALLOC_LOCK.lock().unwrap();
+    ensure_global_allocator();
+
+    let store = new_store(1024, 1, 256);
+    assert_eq!(
+        unsafe { spacewasm_resume(store) },
+        status::SPACEWASM_ERR_WRONG_STATE,
+        "resume on a non-paused engine must fail, not abort"
+    );
+    assert_eq!(
+        unsafe { spacewasm_resume_value(store, i32_val(1)) },
+        status::SPACEWASM_ERR_WRONG_STATE,
+        "resume_value on a non-paused engine must fail, not abort"
+    );
+    unsafe { spacewasm_destroy(store) };
+}
+
+#[test]
+fn resume_mismatch_keeps_paused_state() {
+    let _guard = ALLOC_LOCK.lock().unwrap();
+    ensure_global_allocator();
+
+    let mut host = core::mem::MaybeUninit::<spacewasm_host_t>::uninit();
+    assert_eq!(
+        unsafe { spacewasm_host_new(1, host.as_mut_ptr()) },
+        status::SPACEWASM_OK
+    );
+
+    let mut hmod = 0u32;
+    unsafe {
+        assert_eq!(
+            spacewasm_add_host_module(host.as_mut_ptr(), c"env".as_ptr(), 1, 0, &mut hmod),
+            status::SPACEWASM_OK
+        );
+        assert_eq!(
+            spacewasm_add_host_function(
+                host.as_mut_ptr(),
+                hmod,
+                c"pause_i32".as_ptr(),
+                c"".as_ptr(),
+                c"i".as_ptr(),
+                Some(pause_i32_host),
+                core::ptr::null_mut(),
+            ),
+            status::SPACEWASM_OK
+        );
+    }
+
+    let mut store: *mut CEngine = core::ptr::null_mut();
+    assert_eq!(
+        unsafe { spacewasm_new(host.as_mut_ptr(), 1024, 1, opts(256), &mut store) },
+        status::SPACEWASM_OK
+    );
+
+    let alloc = new_guest_allocator();
+    let idx = load_module_onto(alloc, store, c"main", PAUSE_I32_WASM, 0).expect("load");
+
+    let mut func = 0u32;
+    assert_eq!(
+        unsafe { spacewasm_find_export_func(store, idx, c"test_pause_i32".as_ptr(), &mut func) },
+        status::SPACEWASM_OK
+    );
+
+    assert_eq!(
+        unsafe { spacewasm_invoke(store, idx, func, core::ptr::null(), 0) },
+        status::SPACEWASM_OK
+    );
+
+    let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
+    assert_eq!(
+        unsafe { spacewasm_run(store, 10000, &mut trap) },
+        spacewasm_run_status_t::SPACEWASM_RUN_PAUSE,
+        "should pause"
+    );
+
+    // Wrong resume shapes fail without consuming the paused state: no value at
+    // all, and a value of the wrong type.
+    assert_eq!(
+        unsafe { spacewasm_resume(store) },
+        status::SPACEWASM_ERR_WRONG_STATE,
+        "resume without the declared value must fail, not abort"
+    );
+    let wrong_ty = spacewasm_value_t {
+        tag: spacewasm_valtype_t::SPACEWASM_F32,
+        u: spacewasm_value_payload_t { f32_: 1.5 },
+    };
+    assert_eq!(
+        unsafe { spacewasm_resume_value(store, wrong_ty) },
+        status::SPACEWASM_ERR_WRONG_STATE,
+        "resume with the wrong value type must fail, not abort"
+    );
+
+    // The engine is still paused: retry with the correct value succeeds.
+    assert_eq!(
+        unsafe { spacewasm_resume_value(store, i32_val(99)) },
+        status::SPACEWASM_OK,
+        "retry with the correct value"
+    );
+    assert_eq!(
+        run_to_completion(store, &mut trap),
+        spacewasm_run_status_t::SPACEWASM_RUN_FINISHED,
+        "run (trap={trap:?})"
+    );
+    let mut out = i32_val(0);
+    assert_eq!(
+        unsafe { spacewasm_get_result(store, spacewasm_valtype_t::SPACEWASM_I32, &mut out) },
+        status::SPACEWASM_OK
+    );
+    assert_eq!(unsafe { out.u.i32_ }, 99);
+
+    unsafe {
+        spacewasm_destroy(store);
+        spacewasm_allocator_destroy(alloc);
+    }
+}
+
+#[test]
 fn error_paths() {
     let _guard = ALLOC_LOCK.lock().unwrap();
     ensure_global_allocator();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -149,28 +149,45 @@ impl Engine {
 
     /// Resume the interpreter after a host pause.
     /// Optionally pushes a value to the operand stack as a host function return value.
-    pub fn resume(&mut self, resume_value: Option<Value>) {
-        // Unwrap is safe here because we should not call resume() unless the interpreter requested a pause
-        match (self.host_pause_result.take().unwrap(), resume_value) {
+    ///
+    /// Returns `false` without modifying interpreter state if the engine is
+    /// not paused, or if `resume_value` does not match the paused host
+    /// function's declared result type (the caller may retry with the correct
+    /// value).
+    pub fn resume(&mut self, resume_value: Option<Value>) -> bool {
+        let Some(expected) = self.host_pause_result else {
+            return false;
+        };
+
+        let resumed = match (expected, resume_value) {
             (ResultType(Some(ValType::F32)), Some(Value::F32(z))) => {
                 self.stack.write_f32(self.sp, z);
                 self.sp += 1;
+                true
             }
             (ResultType(Some(ValType::F64)), Some(Value::F64(z))) => {
                 self.stack.write_f64(self.sp, z);
                 self.sp += 2;
+                true
             }
             (ResultType(Some(ValType::I32)), Some(Value::I32(n))) => {
                 self.stack.write_u32(self.sp, n as u32);
                 self.sp += 1;
+                true
             }
             (ResultType(Some(ValType::I64)), Some(Value::I64(n))) => {
                 self.stack.write_u64(self.sp, n as u64);
                 self.sp += 2;
+                true
             }
-            (ResultType(None), None) => {}
-            _ => panic!("expected host function to return a value"),
+            (ResultType(None), None) => true,
+            _ => false,
+        };
+
+        if resumed {
+            self.host_pause_result = None;
         }
+        resumed
     }
 }
 

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -669,7 +669,10 @@ fn invoke_function_resume(
         .borrow_mut()
         .push(format!("resume {:?}", resume_value));
 
-    ctx.engine.resume(resume_value);
+    assert!(
+        ctx.engine.resume(resume_value),
+        "resume failed: engine not paused or resume value type mismatch"
+    );
 
     // Continue execution from the paused state
     let test_runner: Inspector<'_, _, _, _> = Inspector {


### PR DESCRIPTION
## Problem

`Engine::resume()` unwraps the paused state and panics when the resume
value does not match the paused host function's declared result type.
Across the C FFI (`panic = "abort"`, delegated panic handler), this means
an ordinary embedder mistake kills the whole process:

- `spacewasm_resume` / `spacewasm_resume_value` called while the engine is
  not paused;
- `spacewasm_resume_value` called with a value whose type does not match
  the paused function's result type.

## Change

- `Engine::resume()` returns `bool`. On failure (not paused, or mismatched
  resume value) it leaves interpreter state untouched, so the caller can
  recover and retry with the correct value.
- `spacewasm_resume` / `spacewasm_resume_value` map failure to the existing
  `SPACEWASM_ERR_WRONG_STATE` status instead of aborting.
- The spec test harness now checks the `resume()` result instead of
  discarding it.

**Breaking change (Rust API):** `Engine::resume()` changes signature from
`-> ()` to `-> bool`. Callers ignoring the result are unaffected; behavior
on correct usage is unchanged. Happy to reshape this (e.g. a dedicated
error type) if you prefer something richer than `bool`.

## Tests

New C-API regression tests:

- `resume_without_pause_returns_wrong_state` — both resume entry points on
  a non-paused engine return `SPACEWASM_ERR_WRONG_STATE`;
- `resume_mismatch_keeps_paused_state` — resuming a paused i32 function
  without a value, and with an f32 value, both fail with
  `SPACEWASM_ERR_WRONG_STATE` without consuming the paused state; a
  subsequent correct retry resumes and completes with the expected result.

Full workspace suite passes locally (`cargo test --workspace`, wabt 1.0.41).

## AI assistance

Generative AI tools assisted with analysis and drafting; all changes were
reviewed and tested against the v0.4.4 source.
