### PR TITLE
Make Engine::push_module fallible

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -265,7 +265,7 @@ pub fn no_traps(wasm: &[u8]) {
     // Borrow the compiled text straight from the builder (no copy needed).
     let text = code_builder.pages();
 
-    let module_ref = state.push_module(module);
+    let module_ref = state.push_module(module).unwrap();
     let start_result = match state.invoke_start(module_ref) {
         StartInvocation::Finished => InterpreterResult::Finished,
         StartInvocation::Trap(t) => InterpreterResult::Trap(t),

--- a/crates/spacewasi/src/main.rs
+++ b/crates/spacewasi/src/main.rs
@@ -180,7 +180,7 @@ fn main() {
 
     // Append the module and run its start function (if any). The interpreter
     // reads code directly from the builder's pages.
-    let module_ref = engine.push_module(module);
+    let module_ref = engine.push_module(module).unwrap();
     let init_result = match engine.invoke_start(module_ref) {
         StartInvocation::Finished => InterpreterResult::Finished,
         StartInvocation::Trap(t) => InterpreterResult::Trap(t),

--- a/crates/spacewasm_c_api/src/capi.rs
+++ b/crates/spacewasm_c_api/src/capi.rs
@@ -289,7 +289,11 @@ pub unsafe extern "C" fn spacewasm_load_module(
         Err(e) => return status::parse_status(&e),
     };
 
-    let module_ref = cengine.engine.push_module(module);
+    let module_ref = match cengine.engine.push_module(module) {
+        Ok(m) => m,
+        Err(_) => return status::SPACEWASM_ERR_CAPACITY,
+    };
+
     let idx = module_ref.0 as u32;
 
     if !out_module_idx.is_null() {

--- a/crates/spacewasm_std/benches/coremark.rs
+++ b/crates/spacewasm_std/benches/coremark.rs
@@ -81,7 +81,7 @@ fn main() {
 
     let text = code_builder.pages();
 
-    let module_ref = state.push_module(module);
+    let module_ref = state.push_module(module).unwrap();
     match state.invoke_start(module_ref) {
         StartInvocation::Finished => {}
         StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -152,7 +152,7 @@ fn main() {
     let text = code_builder.pages();
     let final_page_offset = code_builder.offset();
 
-    let module_ref = state.push_module(module);
+    let module_ref = state.push_module(module).unwrap();
     match state.invoke_start(module_ref) {
         StartInvocation::Finished => {}
         StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),

--- a/crates/spacewasm_util/src/bin/spacewasm-trace.rs
+++ b/crates/spacewasm_util/src/bin/spacewasm-trace.rs
@@ -217,7 +217,7 @@ fn main() {
 
     // Initialize with instruction limit to prevent infinite loops in start functions
     // Catch panics (e.g., from strict-assertions) during initialization
-    let module_ref = state.push_module(module);
+    let module_ref = state.push_module(module).unwrap();
     let init_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         match state.invoke_start(module_ref) {
             StartInvocation::Finished => InterpreterResult::Finished,

--- a/src/interpreter_tests.rs
+++ b/src/interpreter_tests.rs
@@ -75,7 +75,7 @@ mod tests {
             exports: crate::Vec::zero(),
         };
 
-        let module_ref = engine.push_module(module);
+        let module_ref = engine.push_module(module).unwrap();
         match engine.invoke_start(module_ref) {
             StartInvocation::Finished => {}
             StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),

--- a/src/store.rs
+++ b/src/store.rs
@@ -176,9 +176,9 @@ impl Engine {
     /// Append a module to the store without running its start function.
     /// Note: The start function still needs to be run (if there is one)
     /// Returns the ModuleRef of the new module
-    pub fn push_module(&mut self, module: Module) -> ModuleRef {
-        self.store.modules.push(module);
-        ModuleRef((self.store.modules.len() - 1) as u8)
+    pub fn push_module(&mut self, module: Module) -> Result<ModuleRef, AllocError> {
+        self.store.modules.try_push(module)?;
+        Ok(ModuleRef((self.store.modules.len() - 1) as u8))
     }
 
     /// Returns `true` if the engine is idle (not currently executing)

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -620,7 +620,7 @@ fn load_module(
     )?;
 
     // Append the module and run its start function.
-    let module_ref = ctx.engine.push_module(module);
+    let module_ref = ctx.engine.push_module(module).unwrap();
     let result = match ctx.engine.invoke_start(module_ref) {
         StartInvocation::Finished => InterpreterResult::Finished,
         StartInvocation::Trap(t) => InterpreterResult::Trap(t),


### PR DESCRIPTION
Most of the public SpaceWasm API has `Result<>` returns. This updates `Engine::push_module` to use `Vec::try_push` instead of `Vec::push` so that a push_module can fail instead of panic if it goes over the module capacity. I've also updated the C API to return ERR_CAPACITY when this happens which makes the public API cleaner.
