### PR TITLE
Track SPACEWASM_CONFIG changes in the c_api build script

### DIFF
--- a/crates/spacewasm_c_api/build.rs
+++ b/crates/spacewasm_c_api/build.rs
@@ -15,12 +15,13 @@ fn main() {
         }
     };
 
+    println!("cargo:rerun-if-env-changed=SPACEWASM_CONFIG");
     println!("cargo:rustc-env=SPACEWASM_CONFIG={config}");
     generate_header();
 }
 
 /// Regenerate `include/spacewasm.h` from the Rust source with cbindgen. Only
-/// compiled in when the `generate-header` feature is on; otherwise a no-op so
+/// compiled in when the `codegen` feature is on; otherwise a no-op so
 /// lean builds carry no cbindgen dependency and consume the committed header.
 #[cfg(feature = "codegen")]
 fn generate_header() {


### PR DESCRIPTION
`build.rs` reads `SPACEWASM_CONFIG` but never emits `cargo:rerun-if-env-changed` for it, so cargo does not rebuild when the variable changes — the previous configuration stays compiled in.

This breaks the workflow `crates/spacewasm_c_example/README.md` documents:

```sh
SPACEWASM_CONFIG=my_config.rs cargo build -p spacewasm_c_api
```

### Reproduction

On `23a1db2`, point the variable at a file that is not valid Rust:

| target dir | result |
| --- | --- |
| clean | `exit 101` — the file is read |
| already built with another config | **`exit 0`** — build succeeds, cargo reports `Fresh` |

A build that must fail passes, and `target/debug/build/spacewasm_c_api-*/output` still records the old path. So `MAX_CONTROL_FRAMES`, `MAX_STACK_DEPTH`, `GLOBAL_ALLOCATOR_MAX_PAGES` and `GLOBAL_ALLOCATOR_PAGE_SIZE` can silently keep the previous build's values.

### Fix

One line. Editing the config file's *contents* is already tracked through `include!` dep-info, so `rerun-if-changed` is not needed:

| build.rs | env change | external file edit | default config edit |
| --- | --- | --- | --- |
| current | **missed** | ok | ok |
| `rerun-if-env-changed` only | ok | ok | ok |
| both directives | ok | ok | ok |

Also corrects the doc comment above `generate_header()`, which names a `generate-header` feature; the `cfg` gate and `Cargo.toml` both use `codegen`.

### Checks

Debian bookworm, rustc 1.97.1: `cargo fmt --all -- --check`, `cargo clippy -p spacewasm_c_api --all-targets -- -D warnings`, `cargo test -p spacewasm_c_api` (35 passed), `cargo test -p spacewasm_c_example` (2 passed).

*AI-assisted (Claude Code) per `AI_POLICY.md`; I ran every command above myself.*
