### PR TITLE
Silence the stray debug print in fd_fdstat_set_rights

### DIFF
--- a/crates/spacewasi/src/wasi_preview1.rs
+++ b/crates/spacewasi/src/wasi_preview1.rs
@@ -373,8 +373,6 @@ pub fn make_wasi_preview1_module(wasi_ctx: wasi_common::WasiCtx) -> HostModule {
                         panic!("expected i64");
                     };
 
-                    // eprintln!("fd_fdstat_set_rights({a0}, {a1}, {a2})");
-
                     let code = block_on(wasi_snapshot_preview1::fd_fdstat_set_rights(
                         &mut *wasi_ctx_fd_fdstat_set_rights.borrow_mut(),
                         &mut GuestMemory::Shared(unsafe {

--- a/crates/spacewasi/src/wasi_preview1.rs
+++ b/crates/spacewasi/src/wasi_preview1.rs
@@ -373,7 +373,7 @@ pub fn make_wasi_preview1_module(wasi_ctx: wasi_common::WasiCtx) -> HostModule {
                         panic!("expected i64");
                     };
 
-                    eprintln!("fd_fdstat_set_rights({a0}, {a1}, {a2})");
+                    // eprintln!("fd_fdstat_set_rights({a0}, {a1}, {a2})");
 
                     let code = block_on(wasi_snapshot_preview1::fd_fdstat_set_rights(
                         &mut *wasi_ctx_fd_fdstat_set_rights.borrow_mut(),


### PR DESCRIPTION
`wasi_preview1.rs:376` is the only uncommented `eprintln!` of the 49 in this file, so a guest calling `fd_fdstat_set_rights` writes a debug line to the host's stderr:

```
$ spacewasi rights.wasm
fd_fdstat_set_rights(1, 0, 0)
```

The same module against `fd_fdstat_get` prints nothing. `tests/integration.rs` asserts only on stdout, which is why this went unnoticed.

Commented out to match the other 48 rather than removed. `cargo test -p spacewasi` stays at 7 passed.

*AI-assisted (Claude Code) per `AI_POLICY.md`.*
