### PR TITLE
Fix the broken IR spec link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For more information about this command and basic WASI compilation, see [`spacew
 This Wasm interpreter imposes additional constraints beyond the WebAssembly 1.0 specification to support
 resource-constrained spacecraft environments.
 
-See our [IR SPEC](./src/SPEC.md) for the full list of limitations.
+See our [IR SPEC](./docs/ir.md#limitations) for the full list of limitations.
 
 These constraints enable deterministic memory usage and efficient execution in resource-constrained environments while
 maintaining compatibility with most standard WebAssembly modules.


### PR DESCRIPTION
`README.md` links to `./src/SPEC.md`, which does not exist — the link 404s on GitHub.

`src/SPEC.md` was moved to `docs/ir.md` by #121 (`2e1ca1b`, "Move relavent docs to docs directory"), but this reference, added earlier in #49 (`d4cd85d`), was not updated with it. `docs/ir.md` is titled "SpaceWasm IR Specification" and carries the `## Limitations` section the sentence refers to, so the link now points at that heading.

It is the only broken relative link in the repo — I checked all 16 across the 9 markdown files.

*AI-assisted (Claude Code) per `AI_POLICY.md`.*
