### PR TITLE
Add a CI job covering the CMake integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,51 @@ jobs:
       - name: Build release
         run: cargo build --workspace --release --verbose
 
+  cmake:
+    name: CMake Integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install aarch64 cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      # `crates/spacewasm_c_api/README.md` documents consuming the crate through
+      # `add_subdirectory()`, but nothing in CI configures it. The fixture builds
+      # the same two C programs `spacewasm_c_example` already drives through
+      # cargo, so the CMake path gets covered without new test code. Both embed
+      # their module bytes, so unlike the rest of the suite this needs no WABT.
+      - name: Build and run the documented integration
+        run: |
+          cmake -S crates/spacewasm_c_api/tests/cmake -B target/cmake/native \
+            -DCMAKE_BUILD_TYPE=Debug
+          cmake --build target/cmake/native -j"$(nproc)"
+          ./target/cmake/native/ctest
+          ./target/cmake/native/ctest_suite
+
+      # A cross build has to forward the Rust target explicitly. Without
+      # `SPACEWASM_TARGET` cargo still produces a host archive and the link fails
+      # with "file in wrong format", so assert the emitted ELF is AArch64.
+      - name: Cross-compile to aarch64
+        run: |
+          cmake -S crates/spacewasm_c_api/tests/cmake -B target/cmake/aarch64 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DSPACEWASM_TARGET=aarch64-unknown-linux-gnu
+          cmake --build target/cmake/aarch64 -j"$(nproc)"
+          readelf -h target/cmake/aarch64/ctest | grep -q AArch64
+
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest

--- a/crates/spacewasm_c_api/tests/cmake/CMakeLists.txt
+++ b/crates/spacewasm_c_api/tests/cmake/CMakeLists.txt
@@ -1,0 +1,21 @@
+####
+# CMake integration fixture.
+#
+# Consumes `spacewasm_c_api` exactly the way `crates/spacewasm_c_api/README.md`
+# tells an integrator to: `add_subdirectory()` plus a link against `spacewasm`.
+# The programs built here are the same ones `spacewasm_c_example`'s `c_abi.rs`
+# drives through cargo, so this adds coverage of the CMake path without adding
+# test code. Both are self-contained (module bytes are embedded, no file I/O),
+# so unlike the rest of the suite this needs no WABT.
+####
+cmake_minimum_required(VERSION 3.12)
+project(spacewasm_cmake_integration C)
+
+add_subdirectory(../.. spacewasm_c_api)
+
+set(SPACEWASM_C_EXAMPLES ${CMAKE_CURRENT_SOURCE_DIR}/../../../spacewasm_c_example/examples)
+
+foreach(prog ctest ctest_suite)
+  add_executable(${prog} ${SPACEWASM_C_EXAMPLES}/${prog}.c)
+  target_link_libraries(${prog} PRIVATE spacewasm)
+endforeach()


### PR DESCRIPTION
_Rebased onto `main` (2eceda3) on 2026-09-03: actions pinned to the SHAs `ci.yml` uses since #180; the fixture re-verified against the `CMakeLists.txt` changes in #189 (native run: `add(20, 22) = 42`, `all 12 C ABI tests passed`). Numbers below are from the original branch._

Closes #148. Opening this as a concrete shape for that proposal — happy to reshape or drop it.

Nothing in `ci.yml` configures `crates/spacewasm_c_api/CMakeLists.txt`, so the `add_subdirectory()` integration its README documents is only exercised by hand. `tests/c_abi.rs` already runs `examples/ctest.c` and `examples/ctest_suite.c`, but reaches them through cargo.

This adds a fixture that reaches the same two programs through CMake, and a job that builds them natively and cross-compiles to aarch64. No new test code.

Measured on this branch (Debian bookworm, CMake 3.25.1, 12 cores):

| step | result | time |
| --- | --- | --- |
| native | `add(20, 22) = 42` / `all 11 C ABI tests passed` (12 on 2eceda3) | 19 s |
| cross aarch64 | `ELF 64-bit LSB pie executable, ARM aarch64` | 7 s |

Both C programs embed their module bytes, so this is the only job that needs no WABT. Output goes under `target/`, already gitignored, and the fixture adds no cargo target.

The `include(GNUInstallDirs)` omission fixed in #130 failed at configure time, so the native step would have caught it. The cross step pins what the README promises — drop `SPACEWASM_TARGET` and cargo still builds, but emits an x86-64 archive and the link fails with `file in wrong format`.

Kept aarch64 rather than i686 since `test-32bit` already covers 32-bit.

*Disclosure per `AI_POLICY.md`: AI-assisted (Claude Code) — fixture, job and this description. I ran every command above; the numbers are from those runs.*

