### PR TITLE
remove unused headers in spacewasm.h

### DIFF
--- a/crates/spacewasm_c_api/cbindgen.toml
+++ b/crates/spacewasm_c_api/cbindgen.toml
@@ -3,6 +3,8 @@ include_guard = "SPACEWASM_H"
 tab_width = 4
 documentation_style = "c"
 cpp_compat = true
+no_includes = true
+sys_includes = ["stdbool.h", "stdint.h", "stddef.h"]
 # Render Rust `usize`/`isize` as `size_t`/`ptrdiff_t` rather than `uintptr_t`.
 usize_is_size_t = true
 header = """/*

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -6,11 +6,9 @@
 #ifndef SPACEWASM_H
 #define SPACEWASM_H
 
-#include <stdarg.h>
 #include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 /*
  Operation status returned by most `spacewasm_*` functions.


### PR DESCRIPTION
The `spacewasm.h` C API header includes `stdarg.h` and `stdlib.h` are not needed, but they are added by default by cbindgen. This PR just removes the default header includes, while manually adding the required `stdbool.h`, `stdint.h`, and `stddef.h` back in.