### PR TITLE
Add a regression test for host allocators that return null

### DIFF
--- a/crates/spacewasm_util/tests/page_null.rs
+++ b/crates/spacewasm_util/tests/page_null.rs
@@ -1,0 +1,36 @@
+//! A page allocation that fails must be reported as an error, not handed back as
+//! a successful allocation based at address zero.
+//!
+//! This rests on the real system allocator returning NULL, which Miri does not
+//! model, so it is excluded there like the other integration tests.
+#![cfg(not(miri))]
+
+use spacewasm::{Allocator, PageAllocator};
+use spacewasm_util::RustSystemAllocator;
+use std::alloc::Layout;
+
+/// Under `isize::MAX` so `Layout` accepts it, but far beyond the address space of
+/// either pointer width, so the request cannot be satisfied and the system
+/// allocator returns NULL.
+const UNSATISFIABLE_PAGE: usize = 1usize << (usize::BITS - 2);
+
+#[test]
+fn failed_page_allocation_is_reported_as_an_error() {
+    let page_layout = Layout::from_size_align(UNSATISFIABLE_PAGE, 8).unwrap();
+
+    // Guard against a platform that somehow satisfies the request: without a real
+    // failure there is nothing to observe, so leave rather than assert.
+    let probe = unsafe { std::alloc::alloc(page_layout) };
+    if !probe.is_null() {
+        unsafe { std::alloc::dealloc(probe, page_layout) };
+        eprintln!("skipped: the system satisfied a {UNSATISFIABLE_PAGE:#x} byte request");
+        return;
+    }
+
+    let page_alloc: PageAllocator<RustSystemAllocator, 4> =
+        PageAllocator::new(RustSystemAllocator, UNSATISFIABLE_PAGE);
+
+    if let Ok(ptr) = unsafe { page_alloc.alloc(Layout::from_size_align(16, 8).unwrap()) } {
+        panic!("reported success with {ptr:p} after the page could not be allocated");
+    }
+}

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -189,7 +189,12 @@ unsafe impl Allocator for SpecTestAllocator {
             AllocPhase::Loading { freed: false } | AllocPhase::Unchecked => {}
         });
 
-        unsafe { Ok(std::alloc::alloc(layout)) }
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        if ptr.is_null() {
+            Err(AllocError::AllocationFailed)
+        } else {
+            Ok(ptr)
+        }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {


### PR DESCRIPTION
Rebased onto `main`. #189 landed the null check this PR proposed, in `RustSystemAllocator` (`crates/spacewasm_util/src/lib.rs:15-20`) and in the fuzzing `SystemAllocator`, so the fix itself is gone from the diff. What is left:

- `crates/spacewasm_util/tests/page_null.rs`: a `PageAllocator` over `RustSystemAllocator` must report an unsatisfiable page as `Err`, not serve a page at address zero. Passes on `main`; with the `lib.rs` check reverted it fails.
- `tests/util/spectest.rs`: the same check in `SpecTestAllocator`, the one allocator of that shape #189 did not touch.

Verified on 2eceda3: fmt, clippy (`--workspace --all-targets --all-features -D warnings`), `page_null` on x86-64 and i686, also with `strict-assertions`, and `regression_integration`. Happy to close instead if you would rather not carry the test.

*AI use per `AI_POLICY.md`: Claude Code assisted with the rebase, the verification runs and this description; scope is `crates/spacewasm_util/tests/` and `tests/util/`, no `src/` change.*
