### PR TITLE
Disallow module start to be mapped to host function

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -308,11 +308,15 @@ pub fn no_traps(wasm: &[u8]) {
     let text = code_builder.pages();
 
     let module_ref = state.push_module(module).unwrap();
-    let start_result = match state.invoke_start(module_ref) {
-        StartInvocation::Finished => InterpreterResult::Finished,
-        StartInvocation::Trap(t) => InterpreterResult::Trap(t),
-        StartInvocation::Pause => InterpreterResult::Pause,
-        StartInvocation::Running => Interpreter.run(text, &mut state, 10000),
+    let start_result = match state.module_start(module_ref) {
+        None => InterpreterResult::Finished,
+        Some(start) => match state.invoke(start, &[]) {
+            Ok(()) => Interpreter.run(text, &mut state, 10000),
+            Err(InvokeError::StackOverflow) => InterpreterResult::Trap(TrapReason::StackOverflow),
+            // The start function is validated to be `[] -> []`, so parameter
+            // length/type mismatches cannot occur.
+            Err(_) => unreachable!(),
+        },
     };
     match start_result {
         InterpreterResult::Finished => {}

--- a/crates/spacewasi/src/main.rs
+++ b/crates/spacewasi/src/main.rs
@@ -18,7 +18,7 @@
 /// Portions of this file are derived from <https://github.com/crossterm-rs/crossterm>
 use spacewasm::{
     CodeBuilder, CompilerOptions, Engine, ExportDesc, Interpreter, InterpreterResult,
-    InterpreterRunner, ModuleRef, PageAllocator, Ref, StartInvocation, WasmRef,
+    InterpreterRunner, InvokeError, ModuleRef, PageAllocator, Ref, TrapReason, WasmRef,
 };
 mod wasi_preview1;
 use crate::wasi_preview1::make_wasi_preview1_module;
@@ -194,11 +194,13 @@ fn main() {
     // Append the module and run its start function (if any). The interpreter
     // reads code directly from the builder's pages.
     let module_ref = engine.push_module(module).unwrap();
-    let init_result = match engine.invoke_start(module_ref) {
-        StartInvocation::Finished => InterpreterResult::Finished,
-        StartInvocation::Trap(t) => InterpreterResult::Trap(t),
-        StartInvocation::Pause => InterpreterResult::Pause,
-        StartInvocation::Running => Interpreter.run(code_builder.pages(), &mut engine, usize::MAX),
+    let init_result = match engine.module_start(module_ref) {
+        None => InterpreterResult::Finished,
+        Some(start) => match engine.invoke(start, &[]) {
+            Ok(()) => Interpreter.run(code_builder.pages(), &mut engine, usize::MAX),
+            Err(InvokeError::StackOverflow) => InterpreterResult::Trap(TrapReason::StackOverflow),
+            Err(_) => unreachable!(),
+        },
     };
     match init_result {
         InterpreterResult::Finished => {}

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -119,6 +119,7 @@ enum spacewasm_status_t
     SPACEWASM_ERR_GLOBAL_TYPE_MISMATCH = 164,
     SPACEWASM_ERR_ALIGNMENT_LARGER_THAN_TYPE = 165,
     SPACEWASM_ERR_INVALID_START_FUNCTION_SIGNATURE = 166,
+    SPACEWASM_ERR_INVALID_HOST_START_FUNCTION = 167,
     SPACEWASM_ERR_CONST_ALREADY_HAS_VALUE = 176,
     SPACEWASM_ERR_CONST_NO_VALUE = 177,
     SPACEWASM_ERR_CONST_INVALID_GLOBAL = 178,
@@ -526,7 +527,8 @@ spacewasm_status_t spacewasm_add_host_function(struct spacewasm_host_t *host,
  Load a guest module named `name` onto an existing engine by streaming its
  bytes through the `read` callback. The callback owns the buffer backing each
  chunk (see [`spacewasm_read_fn_t`]). This does not run the module's start
- function; use [`spacewasm_invoke_start`] for that. `allocator` supplies the
+ function; resolve it with [`spacewasm_module_start`] and invoke it with
+ [`spacewasm_invoke`] for that. `allocator` supplies the
  guest linear memory (see [`spacewasm_allocator_new`]). Writes the new module's
  index to `out_module_idx` (if non-null). May be called repeatedly to load
  several modules onto the same engine.
@@ -595,18 +597,29 @@ spacewasm_status_t spacewasm_find_export_func(struct spacewasm_t *engine,
                                               uint32_t *out_index);
 
 /*
- Invoke the start function of a module.
+ Look up the start function of module `module_idx` and write its location to
+ `out_module_idx` and `out_func_index`.
 
- If there is no start function, return [`spacewasm_run_status_t::SPACEWASM_RUN_FINISHED`]
- If there is a start function, return [`spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL`]
+ Start functions are never host functions (that is rejected at load time), so
+ the result is always a directly-invokable Wasm function. The written indices
+ can be passed straight to [`spacewasm_invoke`] followed by [`spacewasm_run`],
+ exactly as you would an exported function. Note that `out_module_idx` may
+ differ from `module_idx` when the start is an imported (cross-module)
+ function.
 
- If there are any bad arguments or the start function is a host function that traps,
- return [`spacewasm_run_status_t::SPACEWASM_RUN_TRAP`]
+ Returns [`spacewasm_status_t::SPACEWASM_OK`] and populates the outputs when
+ the module declares a start function. Returns
+ [`spacewasm_status_t::SPACEWASM_ERR_NOT_FOUND`] when `module_idx` is out of
+ range or the module has no start function, in which case there is nothing to
+ invoke.
 
  # Safety
- `engine` must be live
+ `engine` must be live; `out_module_idx` and `out_func_index` valid.
  */
-spacewasm_run_status_t spacewasm_invoke_start(struct spacewasm_t *engine, uint32_t module_idx);
+spacewasm_status_t spacewasm_module_start(struct spacewasm_t *engine,
+                                          uint32_t module_idx,
+                                          uint32_t *out_module_idx,
+                                          uint32_t *out_func_index);
 
 /*
  Set up a call to exported function `func_index` of module `module_idx` with

--- a/crates/spacewasm_c_api/src/capi.rs
+++ b/crates/spacewasm_c_api/src/capi.rs
@@ -5,7 +5,7 @@ use core::ffi::c_void;
 
 use spacewasm::{
     CodeBuilder, CompilerOptions, Engine, ExportDesc, HostFunction, HostModule, Interpreter,
-    InterpreterRunner, Module, ModuleRef, Ref, StartInvocation, ValType, Value, Vec, WasmRef,
+    InterpreterRunner, Module, ModuleRef, Ref, ValType, Value, Vec, WasmRef,
 };
 
 use crate::SpacewasmCaller;
@@ -238,7 +238,8 @@ pub unsafe extern "C" fn spacewasm_add_host_function(
 /// Load a guest module named `name` onto an existing engine by streaming its
 /// bytes through the `read` callback. The callback owns the buffer backing each
 /// chunk (see [`spacewasm_read_fn_t`]). This does not run the module's start
-/// function; use [`spacewasm_invoke_start`] for that. `allocator` supplies the
+/// function; resolve it with [`spacewasm_module_start`] and invoke it with
+/// [`spacewasm_invoke`] for that. `allocator` supplies the
 /// guest linear memory (see [`spacewasm_allocator_new`]). Writes the new module's
 /// index to `out_module_idx` (if non-null). May be called repeatedly to load
 /// several modules onto the same engine.
@@ -448,38 +449,51 @@ pub unsafe extern "C" fn spacewasm_find_export_func(
     status::SPACEWASM_ERR_NOT_FOUND
 }
 
-/// Invoke the start function of a module.
+/// Look up the start function of module `module_idx` and write its location to
+/// `out_module_idx` and `out_func_index`.
 ///
-/// If there is no start function, return [`spacewasm_run_status_t::SPACEWASM_RUN_FINISHED`]
-/// If there is a start function, return [`spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL`]
+/// Start functions are never host functions (that is rejected at load time), so
+/// the result is always a directly-invokable Wasm function. The written indices
+/// can be passed straight to [`spacewasm_invoke`] followed by [`spacewasm_run`],
+/// exactly as you would an exported function. Note that `out_module_idx` may
+/// differ from `module_idx` when the start is an imported (cross-module)
+/// function.
 ///
-/// If there are any bad arguments or the start function is a host function that traps,
-/// return [`spacewasm_run_status_t::SPACEWASM_RUN_TRAP`]
+/// Returns [`spacewasm_status_t::SPACEWASM_OK`] and populates the outputs when
+/// the module declares a start function. Returns
+/// [`spacewasm_status_t::SPACEWASM_ERR_NOT_FOUND`] when `module_idx` is out of
+/// range or the module has no start function, in which case there is nothing to
+/// invoke.
 ///
 /// # Safety
-/// `engine` must be live
+/// `engine` must be live; `out_module_idx` and `out_func_index` valid.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn spacewasm_invoke_start(
+pub unsafe extern "C" fn spacewasm_module_start(
     engine: *mut CEngine,
     module_idx: u32,
-) -> spacewasm_run_status_t {
-    let Some(cengine) = (unsafe { engine.as_mut() }) else {
-        return spacewasm_run_status_t::SPACEWASM_RUN_TRAP;
+    out_module_idx: *mut u32,
+    out_func_index: *mut u32,
+) -> spacewasm_status_t {
+    let Some(cengine) = (unsafe { engine.as_ref() }) else {
+        return status::SPACEWASM_ERR_NULL_ARG;
     };
-
-    if !cengine.engine.is_idle() {
-        return spacewasm_run_status_t::SPACEWASM_RUN_TRAP;
+    if out_module_idx.is_null() || out_func_index.is_null() {
+        return status::SPACEWASM_ERR_NULL_ARG;
     }
 
     if module_idx as usize >= cengine.engine.store.modules().len() {
-        return spacewasm_run_status_t::SPACEWASM_RUN_TRAP;
+        return status::SPACEWASM_ERR_NOT_FOUND;
     }
 
-    match cengine.engine.invoke_start(ModuleRef(module_idx as u8)) {
-        StartInvocation::Finished => spacewasm_run_status_t::SPACEWASM_RUN_FINISHED,
-        StartInvocation::Trap(_) => spacewasm_run_status_t::SPACEWASM_RUN_TRAP,
-        StartInvocation::Pause => spacewasm_run_status_t::SPACEWASM_RUN_PAUSE,
-        StartInvocation::Running => spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL,
+    match cengine.engine.module_start(ModuleRef(module_idx as u8)) {
+        Some(start) => {
+            unsafe {
+                *out_module_idx = start.module.0 as u32;
+                *out_func_index = start.index as u32;
+            }
+            status::SPACEWASM_OK
+        }
+        None => status::SPACEWASM_ERR_NOT_FOUND,
     }
 }
 

--- a/crates/spacewasm_c_api/src/status.rs
+++ b/crates/spacewasm_c_api/src/status.rs
@@ -131,6 +131,7 @@ pub enum spacewasm_status_t {
     SPACEWASM_ERR_GLOBAL_TYPE_MISMATCH = 164,
     SPACEWASM_ERR_ALIGNMENT_LARGER_THAN_TYPE = 165,
     SPACEWASM_ERR_INVALID_START_FUNCTION_SIGNATURE = 166,
+    SPACEWASM_ERR_INVALID_HOST_START_FUNCTION = 167,
 
     // Parse / validation errors - Constant expression validation
     SPACEWASM_ERR_CONST_ALREADY_HAS_VALUE = 176,
@@ -333,6 +334,7 @@ pub fn validation_status(e: &ValidationError) -> spacewasm_status_t {
         ValidationError::InvalidStartFunctionSignature => {
             SPACEWASM_ERR_INVALID_START_FUNCTION_SIGNATURE
         }
+        ValidationError::InvalidHostStartFunction => SPACEWASM_ERR_INVALID_HOST_START_FUNCTION,
         ValidationError::InvalidConstantExpr(ce) => constant_expr_status(ce),
         ValidationError::GuestMemoryAllocationFailure => SPACEWASM_ERR_GUEST_MEMORY_ALLOC_FAILED,
         ValidationError::AllocError(ae) => alloc_status(ae.clone()),

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -285,25 +285,30 @@ fn load_module_onto(
         return Err(st);
     }
 
-    let run = unsafe { spacewasm_invoke_start(store, idx) };
+    // Resolve the start function (if any) and drive it to completion. A module
+    // without a start function reports NOT_FOUND and needs no initialization.
+    let mut start_mod = 0u32;
+    let mut start_func = 0u32;
+    match unsafe { spacewasm_module_start(store, idx, &mut start_mod, &mut start_func) } {
+        status::SPACEWASM_OK => {}
+        status::SPACEWASM_ERR_NOT_FOUND => return Ok(idx),
+        e => return Err(e),
+    }
 
-    // The error codes don't really matter, just spin the start function
-    match run {
-        spacewasm_run_status_t::SPACEWASM_RUN_FINISHED => Ok(idx),
-        spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL => {
-            // We must spin the start function
-            loop {
-                let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
-                let run = unsafe { spacewasm_run(store, 10000, &mut trap) };
-                if run == spacewasm_run_status_t::SPACEWASM_RUN_FINISHED {
-                    break Ok(idx);
-                } else if run != spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL {
-                    break Err(status::SPACEWASM_ERR_WRONG_STATE);
-                }
-            }
+    let st = unsafe { spacewasm_invoke(store, start_mod, start_func, core::ptr::null(), 0) };
+    if st != status::SPACEWASM_OK {
+        return Err(st);
+    }
+
+    // Spin the start function to completion.
+    loop {
+        let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
+        let run = unsafe { spacewasm_run(store, 10000, &mut trap) };
+        if run == spacewasm_run_status_t::SPACEWASM_RUN_FINISHED {
+            break Ok(idx);
+        } else if run != spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL {
+            break Err(status::SPACEWASM_ERR_WRONG_STATE);
         }
-        spacewasm_run_status_t::SPACEWASM_RUN_PAUSE => Err(status::SPACEWASM_ERR_WRONG_STATE),
-        spacewasm_run_status_t::SPACEWASM_RUN_TRAP => Err(status::SPACEWASM_ERR_WRONG_STATE),
     }
 }
 
@@ -1082,6 +1087,10 @@ fn validation_error_codes_map() {
             InvalidStartFunctionSignature,
             status::SPACEWASM_ERR_INVALID_START_FUNCTION_SIGNATURE,
         ),
+        (
+            InvalidHostStartFunction,
+            status::SPACEWASM_ERR_INVALID_HOST_START_FUNCTION,
+        ),
         // Constant expression validation
         (
             InvalidConstantExpr(ConstantExprError::InvalidConstantInstruction),
@@ -1352,7 +1361,7 @@ fn module_with_start_runs() {
     let alloc = new_guest_allocator();
 
     // Stream in without auto-running the start function, so we can observe
-    // `module_needs_start` and drive `run_start` explicitly.
+    // `spacewasm_module_start` and drive the start invocation explicitly.
     let mut cursor = Cursor {
         data: START_WASM,
         pos: 0,
@@ -1374,9 +1383,17 @@ fn module_with_start_runs() {
         "load"
     );
 
+    // Resolve the start function location, then invoke it like any other
+    // exported function.
+    let mut start_mod = 0u32;
+    let mut start_func = 0u32;
     assert_eq!(
-        unsafe { spacewasm_invoke_start(store, idx) },
-        spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL
+        unsafe { spacewasm_module_start(store, idx, &mut start_mod, &mut start_func) },
+        status::SPACEWASM_OK
+    );
+    assert_eq!(
+        unsafe { spacewasm_invoke(store, start_mod, start_func, core::ptr::null(), 0) },
+        status::SPACEWASM_OK
     );
 
     // Drive the start function in small fuel slices to also exercise the
@@ -1417,7 +1434,7 @@ fn module_with_start_runs() {
 }
 
 #[test]
-fn no_start_module_reports_false() {
+fn no_start_module_reports_none() {
     let _guard = ALLOC_LOCK.lock().unwrap();
     ensure_global_allocator();
 
@@ -1425,10 +1442,12 @@ fn no_start_module_reports_false() {
     let alloc = new_guest_allocator();
     let idx = load_module_onto(alloc, store, c"main", ADD_WASM, 0).expect("load");
 
-    // No start function should return finished
+    // A module with no start function has no start location to resolve.
+    let mut start_mod = 0u32;
+    let mut start_func = 0u32;
     assert_eq!(
-        unsafe { spacewasm_invoke_start(store, idx) },
-        spacewasm_run_status_t::SPACEWASM_RUN_FINISHED
+        unsafe { spacewasm_module_start(store, idx, &mut start_mod, &mut start_func) },
+        status::SPACEWASM_ERR_NOT_FOUND
     );
 
     unsafe {
@@ -1899,9 +1918,15 @@ fn start_function_traps() {
         status::SPACEWASM_OK
     );
 
+    let mut start_mod = 0u32;
+    let mut start_func = 0u32;
     assert_eq!(
-        unsafe { spacewasm_invoke_start(store, idx) },
-        spacewasm_run_status_t::SPACEWASM_RUN_OUT_OF_FUEL
+        unsafe { spacewasm_module_start(store, idx, &mut start_mod, &mut start_func) },
+        status::SPACEWASM_OK
+    );
+    assert_eq!(
+        unsafe { spacewasm_invoke(store, start_mod, start_func, core::ptr::null(), 0) },
+        status::SPACEWASM_OK
     );
 
     let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
@@ -1924,13 +1949,15 @@ fn engine_rejects_out_of_range_module() {
     let alloc = new_guest_allocator();
     let _ = load_module_onto(alloc, store, c"main", ADD_WASM, 0).expect("load");
 
-    // module_needs_start on an out-of-range module is trap.
+    // spacewasm_module_start on an out-of-range module is NOT_FOUND.
+    let mut start_mod = 0u32;
+    let mut start_func = 0u32;
     assert_eq!(
-        unsafe { spacewasm_invoke_start(store, 99) },
-        spacewasm_run_status_t::SPACEWASM_RUN_TRAP
+        unsafe { spacewasm_module_start(store, 99, &mut start_mod, &mut start_func) },
+        status::SPACEWASM_ERR_NOT_FOUND
     );
 
-    // run_start on an out-of-range module traps (no such module to seed).
+    // run on an out-of-range module traps (no such module to seed).
     let mut trap = spacewasm_trap_t::SPACEWASM_TRAP_NONE;
     assert_eq!(
         unsafe { spacewasm_run(store, 0, &mut trap) },

--- a/crates/spacewasm_c_example/examples/ctest.c
+++ b/crates/spacewasm_c_example/examples/ctest.c
@@ -157,15 +157,28 @@ int main(void) {
     }
 
     /* Run the module's start function if it declares one. This module does not,
-     * but a well-behaved loader always checks. */
-    spacewasm_run_status_t start_rs = spacewasm_invoke_start(store, mod_idx);
+     * but a well-behaved loader always checks. A NOT_FOUND result means there is
+     * no start function to run. */
     spacewasm_trap_t start_trap = SPACEWASM_TRAP_NONE;
-    while (start_rs == SPACEWASM_RUN_OUT_OF_FUEL) {
-        start_rs = spacewasm_run(store, 1000, &start_trap);
-    }
-
-    if (start_rs != SPACEWASM_RUN_FINISHED) {
-        fprintf(stderr, "run_start: status=%d trap=%d\n", (int)start_rs, (int)start_trap);
+    uint32_t start_mod = 0;
+    uint32_t start_func = 0;
+    spacewasm_status_t start_st = spacewasm_module_start(store, mod_idx, &start_mod, &start_func);
+    if (start_st == SPACEWASM_OK) {
+        st = spacewasm_invoke(store, start_mod, start_func, NULL, 0);
+        if (st != SPACEWASM_OK) {
+            fprintf(stderr, "invoke start: status=%d\n", (int)st);
+            return 1;
+        }
+        spacewasm_run_status_t start_rs = SPACEWASM_RUN_OUT_OF_FUEL;
+        while (start_rs == SPACEWASM_RUN_OUT_OF_FUEL) {
+            start_rs = spacewasm_run(store, 1000, &start_trap);
+        }
+        if (start_rs != SPACEWASM_RUN_FINISHED) {
+            fprintf(stderr, "run_start: status=%d trap=%d\n", (int)start_rs, (int)start_trap);
+            return 1;
+        }
+    } else if (start_st != SPACEWASM_ERR_NOT_FOUND) {
+        fprintf(stderr, "module_start: status=%d\n", (int)start_st);
         return 1;
     }
 

--- a/crates/spacewasm_c_example/examples/ctest_suite.c
+++ b/crates/spacewasm_c_example/examples/ctest_suite.c
@@ -187,19 +187,30 @@ static spacewasm_status_t load_module_onto(spacewasm_allocator_t* alloc, spacewa
         return st;
     }
 
-    spacewasm_run_status_t rs = spacewasm_invoke_start(store, *out_idx);
+    /* Resolve the start function (if any) and drive it to completion. A module
+     * without a start function reports NOT_FOUND and needs no initialization. */
+    uint32_t start_mod = 0;
+    uint32_t start_func = 0;
+    spacewasm_status_t start_st = spacewasm_module_start(store, *out_idx, &start_mod, &start_func);
+    if (start_st == SPACEWASM_ERR_NOT_FOUND) {
+        return SPACEWASM_OK;
+    }
+    if (start_st != SPACEWASM_OK) {
+        return start_st;
+    }
+
+    st = spacewasm_invoke(store, start_mod, start_func, NULL, 0);
+    if (st != SPACEWASM_OK) {
+        return st;
+    }
+
     spacewasm_trap_t trap = SPACEWASM_TRAP_NONE;
+    spacewasm_run_status_t rs = SPACEWASM_RUN_OUT_OF_FUEL;
     while (rs == SPACEWASM_RUN_OUT_OF_FUEL) {
         rs = spacewasm_run(store, 1000, &trap);
     }
 
-    if (rs != SPACEWASM_RUN_FINISHED) {
-        st = SPACEWASM_ERR_WRONG_STATE;
-    } else {
-        st = SPACEWASM_OK;
-    }
-
-    return st;
+    return rs == SPACEWASM_RUN_FINISHED ? SPACEWASM_OK : SPACEWASM_ERR_WRONG_STATE;
 }
 
 static spacewasm_run_status_t run_to_completion(spacewasm_t* store,
@@ -548,7 +559,9 @@ static int test_pause_and_resume_no_value(void) {
           "load_module");
 
     /* No start function */
-    CHECK(spacewasm_invoke_start(store, idx) == SPACEWASM_RUN_FINISHED,
+    uint32_t start_mod = 0;
+    uint32_t start_func = 0;
+    CHECK(spacewasm_module_start(store, idx, &start_mod, &start_func) == SPACEWASM_ERR_NOT_FOUND,
           "no start");
 
     uint32_t func;
@@ -602,7 +615,9 @@ static int test_pause_and_resume_with_value(void) {
           "load_module");
 
     /* No start function */
-    CHECK(spacewasm_invoke_start(store, idx) == SPACEWASM_RUN_FINISHED,
+    uint32_t start_mod = 0;
+    uint32_t start_func = 0;
+    CHECK(spacewasm_module_start(store, idx, &start_mod, &start_func) == SPACEWASM_ERR_NOT_FOUND,
           "no start");
 
     uint32_t func;

--- a/crates/spacewasm_std/benches/coremark.rs
+++ b/crates/spacewasm_std/benches/coremark.rs
@@ -1,7 +1,6 @@
 use spacewasm::{
     CodeBuilder, CompilerOptions, Engine, ExportDesc, HostFunction, HostModule, InterpreterResult,
-    InterpreterRunner, ModuleRef, PageAllocator, RawValue, Ref, StartInvocation, Value,
-    Vec as WasmVec, WasmRef,
+    InterpreterRunner, ModuleRef, PageAllocator, RawValue, Ref, Value, Vec as WasmVec, WasmRef,
 };
 use spacewasm_util::{FileStream, RustSystemAllocator};
 use std::ops::ControlFlow;
@@ -82,17 +81,13 @@ fn main() {
     let text = code_builder.pages();
 
     let module_ref = state.push_module(module).unwrap();
-    match state.invoke_start(module_ref) {
-        StartInvocation::Finished => {}
-        StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),
-        StartInvocation::Pause => panic!("pause during init"),
-        StartInvocation::Running => {
-            match spacewasm::Interpreter.run(text, &mut state, usize::MAX) {
-                InterpreterResult::Finished => {}
-                InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
-                InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
-                InterpreterResult::Pause => panic!("pause during init"),
-            }
+    if let Some(start) = state.module_start(module_ref) {
+        state.invoke(start, &[]).unwrap();
+        match spacewasm::Interpreter.run(text, &mut state, usize::MAX) {
+            InterpreterResult::Finished => {}
+            InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
+            InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
+            InterpreterResult::Pause => panic!("pause during init"),
         }
     }
 

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -1,7 +1,7 @@
 use spacewasm::{
     CodeBuilder, CompilerOptions, ExportDesc, HostFunction, HostFunctionBreak, HostModule,
-    InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref, SectionKind,
-    StartInvocation, ValType, Value, WasmRef, vec,
+    InterpreterResult, InterpreterRunner, ModuleRef, PageAllocator, Ref, SectionKind, ValType,
+    Value, WasmRef, vec,
 };
 use spacewasm_util::{FileStream, RustSystemAllocator};
 use std::ops::ControlFlow;
@@ -153,17 +153,13 @@ fn main() {
     let final_page_offset = code_builder.offset();
 
     let module_ref = state.push_module(module).unwrap();
-    match state.invoke_start(module_ref) {
-        StartInvocation::Finished => {}
-        StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),
-        StartInvocation::Pause => panic!("pause during init"),
-        StartInvocation::Running => {
-            match spacewasm::Interpreter.run(text, &mut state, usize::MAX) {
-                InterpreterResult::Finished => {}
-                InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
-                InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
-                InterpreterResult::Pause => panic!("pause during init"),
-            }
+    if let Some(start) = state.module_start(module_ref) {
+        state.invoke(start, &[]).unwrap();
+        match spacewasm::Interpreter.run(text, &mut state, usize::MAX) {
+            InterpreterResult::Finished => {}
+            InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
+            InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
+            InterpreterResult::Pause => panic!("pause during init"),
         }
     }
 

--- a/crates/spacewasm_util/src/bin/spacewasm-trace.rs
+++ b/crates/spacewasm_util/src/bin/spacewasm-trace.rs
@@ -9,8 +9,8 @@
 
 use spacewasm::{
     AllocError, Allocator, CodeBuilder, CompilerOptions, Engine, ExportDesc, InnerVec, Interpreter,
-    InterpreterResult, InterpreterRunner, MemoryStatistics, Module, ModuleRef, Ref,
-    StartInvocation, Vec as WasmVec, WasmMemoryAllocator, WasmRef, WasmStream,
+    InterpreterResult, InterpreterRunner, InvokeError, MemoryStatistics, Module, ModuleRef, Ref,
+    TrapReason, Vec as WasmVec, WasmMemoryAllocator, WasmRef, WasmStream,
 };
 use spacewasm::{ValType, Value};
 use spacewasm_util::StateTracer;
@@ -219,11 +219,15 @@ fn main() {
     // Catch panics (e.g., from strict-assertions) during initialization
     let module_ref = state.push_module(module).unwrap();
     let init_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        match state.invoke_start(module_ref) {
-            StartInvocation::Finished => InterpreterResult::Finished,
-            StartInvocation::Trap(t) => InterpreterResult::Trap(t),
-            StartInvocation::Pause => InterpreterResult::Pause,
-            StartInvocation::Running => Interpreter.run(text, &mut state, 10000),
+        match state.module_start(module_ref) {
+            None => InterpreterResult::Finished,
+            Some(start) => match state.invoke(start, &[]) {
+                Ok(()) => Interpreter.run(text, &mut state, 10000),
+                Err(InvokeError::StackOverflow) => {
+                    InterpreterResult::Trap(TrapReason::StackOverflow)
+                }
+                Err(_) => unreachable!(),
+            },
         }
     }));
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -118,6 +118,7 @@ pub enum ValidationError {
     GlobalTypeMismatch,
     AlignmentLargerThanType,
     InvalidStartFunctionSignature,
+    InvalidHostStartFunction,
     InvalidConstantExpr(ConstantExprError),
     GuestMemoryAllocationFailure,
     AllocError(AllocError),

--- a/src/interpreter_tests.rs
+++ b/src/interpreter_tests.rs
@@ -4,8 +4,7 @@
 mod tests {
     use crate::{
         AllocError, BaseVisitor, Engine, Interpreter, InterpreterResult, InterpreterRunner,
-        IrVisitor, MemArg, MemType, Memory, MemoryKind, Module, ModuleRef, StartInvocation,
-        ValType,
+        IrVisitor, MemArg, MemType, Memory, MemoryKind, Module, ModuleRef, ValType,
     };
 
     extern crate std;
@@ -76,16 +75,14 @@ mod tests {
         };
 
         let module_ref = engine.push_module(module).unwrap();
-        match engine.invoke_start(module_ref) {
-            StartInvocation::Finished => {}
-            StartInvocation::Trap(t) => panic!("trap during initialization {t:?}"),
-            StartInvocation::Pause => panic!("pause during init"),
-            StartInvocation::Running => match Interpreter.run(&[], &mut engine, usize::MAX) {
+        if let Some(start) = engine.module_start(module_ref) {
+            engine.invoke(start, &[]).unwrap();
+            match Interpreter.run(&[], &mut engine, usize::MAX) {
                 InterpreterResult::Finished => {}
                 InterpreterResult::OutOfFuel => panic!("insufficient fuel for initialization"),
                 InterpreterResult::Trap(t) => panic!("trap during initialization {t:?}"),
                 InterpreterResult::Pause => panic!("pause during init"),
-            },
+            }
         }
 
         engine.memory = engine.store.get_memory(ModuleRef(0)).clone();

--- a/src/module.rs
+++ b/src/module.rs
@@ -352,11 +352,10 @@ impl Module {
                             return Err(ValidationError::InvalidStartFunctionSignature);
                         }
                     }
-                    Ref::Host { module, index } => {
-                        let f = &store.host_modules()[module.0 as usize].functions[index as usize];
-                        if !f.params().is_empty() || f.returns().0.is_some() {
-                            return Err(ValidationError::InvalidStartFunctionSignature);
-                        }
+                    Ref::Host { .. } => {
+                        // We explicitely do not support start mapped to host functions
+                        // It decreases the state space. Just write a wrapper function!
+                        return Err(ValidationError::InvalidHostStartFunction);
                     }
                     Ref::Extern { module, index } => {
                         let m = &store.modules()[module.0 as usize];

--- a/src/store.rs
+++ b/src/store.rs
@@ -193,46 +193,30 @@ impl Engine {
         self.store.modules()[module_ref.0 as usize].start.is_some()
     }
 
-    /// Invoke the module's start function for execution, if it declares one.
-    ///
-    /// The interpreter must be idle (no invocation in flight), matching the
-    /// preconditions of [`Engine::invoke`].
-    pub fn invoke_start(&mut self, module_ref: ModuleRef) -> StartInvocation {
-        let Some(start) = self
+    /// Get the reference to a module's start function
+    /// If the module does not have a start function, return None
+    pub fn module_start(&self, module_ref: ModuleRef) -> Option<WasmRef> {
+        if let Some(start) = self
             .store
             .modules()
             .get(module_ref.0 as usize)
             .and_then(|m| m.start)
-        else {
-            return StartInvocation::Finished;
-        };
-
-        match start {
-            // A local or cross-module Wasm start function is seeded like a
-            // normal invocation; the caller runs the interpreter to drive it.
-            Ref::Module(index) => self.setup_start_invoke(WasmRef {
-                module: module_ref,
-                index,
-            }),
-            Ref::Extern { module, index } => self.setup_start_invoke(WasmRef { module, index }),
-            // Host start functions run immediately; no interpreter loop needed.
-            Ref::Host { module, index } => match self.call_host_fn(module, index, &[]) {
-                HostFunctionResult::Continue(_) => StartInvocation::Finished,
-                HostFunctionResult::Break(HostFunctionBreak::Trap) => {
-                    StartInvocation::Trap(TrapReason::Host)
-                }
-                HostFunctionResult::Break(HostFunctionBreak::Pause) => StartInvocation::Pause,
-            },
-        }
-    }
-
-    fn setup_start_invoke(&mut self, f_ref: WasmRef) -> StartInvocation {
-        match self.invoke(f_ref, &[]) {
-            Ok(()) => StartInvocation::Running,
-            Err(InvokeError::StackOverflow) => StartInvocation::Trap(TrapReason::StackOverflow),
-            // The start function is validated to be `[] -> []`, so parameter
-            // length/type mismatches cannot occur.
-            Err(_) => unreachable!(),
+        {
+            // Unwrap the Ref -> WasmRef since we do not allow start mapped to host functions
+            match start {
+                // A local or cross-module Wasm start function is seeded like a
+                // normal invocation; the caller runs the interpreter to drive it.
+                Ref::Module(index) => Some(WasmRef {
+                    module: module_ref,
+                    index,
+                }),
+                Ref::Extern { module, index } => Some(WasmRef { module, index }),
+                // Mapping start to host functions is not supported in spacewasm
+                // This should have already been checked in the loader
+                Ref::Host { .. } => unreachable!(),
+            }
+        } else {
+            None
         }
     }
 
@@ -247,16 +231,4 @@ impl Engine {
         self.store.host_modules[module.0 as usize].functions[index as usize].finish_call(f);
         r
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StartInvocation {
-    /// There was no start function, or a host start function completed.
-    Finished,
-    /// A Wasm start function was invoked, need to spin the interpreter
-    Running,
-    /// A host start function trapped.
-    Trap(TrapReason),
-    /// A host start function paused
-    Pause,
 }

--- a/tests/core/start.wast
+++ b/tests/core/start.wast
@@ -89,9 +89,14 @@
   (start $main)
 )
 
-(module
-  (func $print (import "spectest" "print"))
-  (start $print)
+;; spacewasm does not allow a module's start function to be mapped directly to
+;; an imported (host) function. Wrap the call in a local function instead.
+(assert_invalid
+  (module
+    (func $print (import "spectest" "print"))
+    (start $print)
+  )
+  "start function must not be a host function"
 )
 
 (assert_trap

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -990,8 +990,10 @@ fn check_decode_error(err: ParseError, text: String) {
         (ValidationError::InvalidNegativeMemOffset, "data segment does not fit") => {}
         (ValidationError::InvalidMemOffsetType, "type mismatch") => {}
         (ValidationError::InvalidStartFunctionSignature, "start function") => {}
-        (ValidationError::InvalidHostStartFunction, "start function must not be a host function") => {
-        }
+        (
+            ValidationError::InvalidHostStartFunction,
+            "start function must not be a host function",
+        ) => {}
         (ValidationError::DuplicateExportName, "duplicate export name") => {}
         (ValidationError::InvalidTableIndex, "unknown table") => {}
         (ValidationError::MemoryError(MemoryError::OutOfBounds), "data segment does not fit") => {}

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 use spacewasm::{
     AllocError, Allocator, CodeBuilder, CompilerOptions, ConstantExprError, Engine, ExportDesc,
     GlobalValue, GlobalValueError, HostFunction, HostGlobal, HostModule, InnerVec, Interpreter,
-    InterpreterResult, InterpreterRunner, Limit, Memory, MemoryError, MemoryStatistics, Module,
-    ModuleRef, ParseError, Ref, StartInvocation, TrapReason, ValType, ValidationError, Value,
-    WasmMemoryAllocator, WasmRef, WasmStream, global_allocator, vec,
+    InterpreterResult, InterpreterRunner, InvokeError, Limit, Memory, MemoryError,
+    MemoryStatistics, Module, ModuleRef, ParseError, Ref, TrapReason, ValType, ValidationError,
+    Value, WasmMemoryAllocator, WasmRef, WasmStream, global_allocator, vec,
 };
 use std::alloc::Layout;
 use std::cell::RefCell;
@@ -689,13 +689,15 @@ fn load_module(
     // allocate nor deallocate.
     let result = {
         let _locked = enter_locked();
-        match ctx.engine.invoke_start(module_ref) {
-            StartInvocation::Finished => InterpreterResult::Finished,
-            StartInvocation::Trap(t) => InterpreterResult::Trap(t),
-            StartInvocation::Pause => InterpreterResult::Pause,
-            StartInvocation::Running => {
-                Interpreter.run(ctx.code_builder.pages(), &mut ctx.engine, usize::MAX)
-            }
+        match ctx.engine.module_start(module_ref) {
+            None => InterpreterResult::Finished,
+            Some(start) => match ctx.engine.invoke(start, &[]) {
+                Ok(()) => Interpreter.run(ctx.code_builder.pages(), &mut ctx.engine, usize::MAX),
+                Err(InvokeError::StackOverflow) => {
+                    InterpreterResult::Trap(TrapReason::StackOverflow)
+                }
+                Err(_) => unreachable!(),
+            },
         }
     };
     match result {
@@ -988,6 +990,8 @@ fn check_decode_error(err: ParseError, text: String) {
         (ValidationError::InvalidNegativeMemOffset, "data segment does not fit") => {}
         (ValidationError::InvalidMemOffsetType, "type mismatch") => {}
         (ValidationError::InvalidStartFunctionSignature, "start function") => {}
+        (ValidationError::InvalidHostStartFunction, "start function must not be a host function") => {
+        }
         (ValidationError::DuplicateExportName, "duplicate export name") => {}
         (ValidationError::InvalidTableIndex, "unknown table") => {}
         (ValidationError::MemoryError(MemoryError::OutOfBounds), "data segment does not fit") => {}


### PR DESCRIPTION
The start/invoke_start API was a point of heavy friction in both the Rust code and the C API wrapper. The reason for this is because we had to handle a very special case where the start function was directly mapped to a host function. The issue was when the start function was "invoked" this really meant either:

1. Start is a normal wasm function, invoke the function
2. Start is a host function, call the function:
  - Host could ask to pause interpreter, ugh what does this mean....
  - Host could trap, another ugh
  - Host returns continue return, no need to spin interpreter anymore since we are "done"

This created a bunch of weird unreachable paths we had to handle. With this slight divergence from the Wasm spec we can avoid this edge case.

I don't expect this divergence will have an effect because as far as I know, no host modules we are using (or that I even know exist) are of signature `[] -> []` which is a requirement for start functions so we are not filtering out any use cases here. If it is _really_ required you can always write a wrapper Wasm function that calls a `[] -> []` host function.