### PR TITLE
Add a CI fuzz job covering x86_64 and i686

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,95 @@ jobs:
         if: matrix.profile == 'release'
         run: cargo test -p spacewasm --release --target i686-unknown-linux-gnu --verbose
 
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            # `cargo fuzz`'s default.
+            sanitizer: address
+          - target: i686-unknown-linux-gnu
+            # rustc ships no AddressSanitizer runtime for 32-bit x86
+            # (`librustc-*_rt.asan.a` exists only for the 64-bit targets), so the
+            # default `-s address` fails at link time. libFuzzer itself is built
+            # from source by `libfuzzer-sys` and works fine without it.
+            sanitizer: none
+
+    env:
+      # Wall-clock budget per fuzz target. Long enough for libFuzzer to get past
+      # the header/section framing and into the decoder proper; short enough that
+      # the job stays comparable to the other checks.
+      FUZZ_SECONDS: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install 32-bit system libraries
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib g++-multilib
+
+      # cargo-fuzz requires nightly for `-Z sanitizer` and the sancov passes.
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cargo-fuzz
+        # Pinned so a cargo-fuzz release cannot change what this job runs. This
+        # is the same tool the Makefile's fuzzing targets already drive; nothing
+        # new is added to the interpreter's dependency graph.
+        run: cargo install cargo-fuzz --locked --version 0.13.2
+
+      - name: Cache Rust dependencies
+        # Pinned commit resolved from the annotated Swatinem/rust-cache@v2 tag.
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          # `fuzz` is excluded from the root workspace and carries its own lockfile.
+          workspaces: fuzz
+          key: ${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-bin: false
+
+      # Nothing else in CI compiles `fuzz/` -- it is excluded from the workspace,
+      # so `cargo build --workspace --all-targets` and clippy both skip it. This
+      # step alone keeps the fuzz targets from rotting.
+      - name: Build fuzz targets
+        run: cargo fuzz build --sanitizer ${{ matrix.sanitizer }} --target ${{ matrix.target }}
+
+      - name: Run fuzz targets
+        # The 32-bit leg currently reproduces #158 (a decoder panic that only
+        # exists when `usize` is 32 bits) within ~100 s, which is the whole point
+        # of fuzzing this target -- but it also means a red job on every PR until
+        # that is fixed. Report it without blocking; drop the `continue-on-error`
+        # below once #158 is closed.
+        continue-on-error: ${{ matrix.target == 'i686-unknown-linux-gnu' }}
+        run: |
+          for target in $(cargo fuzz list); do
+            echo "::group::$target"
+            cargo fuzz run "$target" \
+              --sanitizer ${{ matrix.sanitizer }} \
+              --target ${{ matrix.target }} -- \
+              -max_total_time=${FUZZ_SECONDS} \
+              -rss_limit_mb=4096 \
+              -print_final_stats=1
+            echo "::endgroup::"
+          done
+
+      - name: Upload crash artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,20 @@
 # Target Configuration (auto-detect if not set)
 SPACEWASM_TARGET ?= $(shell rustc -vV | grep 'host:' | cut -d' ' -f2)
 
+# rustc ships no AddressSanitizer runtime for 32-bit x86, so `cargo fuzz`'s
+# default `-s address` fails at link time on i686 looking for
+# `librustc-*_rt.asan.a`. libFuzzer is built from source by `libfuzzer-sys` and
+# does not need it, so drop the sanitizer for that target.
+SPACEWASM_FUZZ_SANITIZER ?= $(if $(findstring i686,$(SPACEWASM_TARGET)),none,address)
+FUZZ_FLAGS = --sanitizer $(SPACEWASM_FUZZ_SANITIZER) --target $(SPACEWASM_TARGET)
+
 # Default target
 help:
 	@echo "SpaceWasm Fuzzing Targets"
 	@echo ""
 	@echo "Configuration:"
-	@echo "  SPACEWASM_TARGET=<triple>   Target architecture (default: $(SPACEWASM_TARGET))"
+	@echo "  SPACEWASM_TARGET=<triple>          Target architecture (default: $(SPACEWASM_TARGET))"
+	@echo "  SPACEWASM_FUZZ_SANITIZER=<name>    Sanitizer for the fuzz targets (default: $(SPACEWASM_FUZZ_SANITIZER))"
 	@echo ""
 	@echo "Fuzzing:"
 	@echo "  make fuzz                          Run the no_traps fuzzer"
@@ -33,13 +41,13 @@ help:
 
 # Run fuzzer
 fuzz:
-	cargo +nightly fuzz run no_traps --target $(SPACEWASM_TARGET)
+	cargo +nightly fuzz run no_traps $(FUZZ_FLAGS)
 
 fuzz-validate:
-	cargo +nightly fuzz run validate --target $(SPACEWASM_TARGET)
+	cargo +nightly fuzz run validate $(FUZZ_FLAGS)
 
 fuzz-malformed:
-	cargo +nightly fuzz run malformed --target $(SPACEWASM_TARGET)
+	cargo +nightly fuzz run malformed $(FUZZ_FLAGS)
 
 # Convert seed to Wasm and trace execution (release mode)
 trace:


### PR DESCRIPTION
Closes #39.

Adds a `Fuzz` job to `ci.yml` — one leg per target, builds all three fuzz targets and gives each a bounded run.

Two things were in the way:

**`fuzz/` is never compiled by CI.** It is `exclude`d from the root workspace, so `cargo build --workspace --all-targets` and clippy both skip it.

**`cargo fuzz` cannot build for i686.** It defaults to `-s address`, and rustc ships no ASan runtime for 32-bit x86:

```
rust-lld: error: cannot open .../i686-unknown-linux-gnu/lib/librustc-nightly_rt.asan.a:
          No such file or directory
```

`--sanitizer none` links fine (libFuzzer is built from source by `libfuzzer-sys`). So `SPACEWASM_TARGET=i686-unknown-linux-gnu make fuzz` fails as written; the Makefile now picks the sanitizer from the target, overridable via `SPACEWASM_FUZZ_SANITIZER`.

## The 32-bit leg pays for itself immediately

Same host, 120 s per target, cold corpus:

| target | x86_64 (ASan) | i686 (`-s none`) |
| --- | --- | --- |
| `malformed` | clean, 194,172 execs | **crash at 97 s**, 193,441 execs |
| `validate` | clean, 167,174 execs | clean, 68,531 execs |
| `no_traps` | clean, 160,543 execs | clean, 49,585 execs |

64-bit ran slightly *more* inputs and stayed clean. The crash is #158 (`Layout::array` on an unbounded vector length). Replaying the saved seed against both builds:

```
i686   panicked at src/util/vec.rs:137:72: called `Result::unwrap()` on an `Err` value: LayoutError
x86_64 Executed crash-158 in 4 ms
```

Seed (base64, 32 bytes): `/xFiAACnp9IQWgAAAAAADgSDg4ODg4ODg4ODhf//WAU=`

That is also why the i686 **run** step is `continue-on-error` — it would be red on every PR until #158 is fixed. The i686 **build** step is blocking. Drop the flag in the PR that closes #158.

## Notes

- `cargo install cargo-fuzz --locked --version 0.13.2` — pinned. Same tool the Makefile already drives; nothing new enters the interpreter's dependency graph.
- `FUZZ_SECONDS: 60` per target. 60 s did not reach the #158 crash in my cold runs (97 s at ~2000 exec/s). Raise it if you want the leg dependable rather than opportunistic.
- Corpora are not persisted, so every run starts cold. Continuous coverage is what #9 is for; this does not overlap.
- The legs are unequal by construction: the 32-bit one hunts pointer-width bugs (`usize`, `Layout` math), not memory-safety bugs.

## AI Usage (see [AI_POLICY.md](https://github.com/nasa/spacewasm/blob/main/AI_POLICY.md))

Tool: Claude Code. Type of assistance: diagnosing the i686 link failure, drafting the CI job, the Makefile change, and this description. Scope: `.github/workflows/ci.yml` and `Makefile` only — no `src/*` change.

Level of modification: substantial. Every number here comes from a container run with nightly + cargo-fuzz 0.13.2 and the i686 target — the failing link, the `-s none` build, all six campaigns, and the seed replay. Its first draft just added the target to a single job and assumed it would build; the link error is what forced the sanitizer split.
