### PR TITLE
More Kani tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub mod test_support {
     }
 }
 
-#[cfg(any(test, kani))]
+#[cfg(test)]
 mod tests {
     use crate::MemoryStatistics;
     use crate::alloc::Allocator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub mod test_support {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, kani))]
 mod tests {
     use crate::MemoryStatistics;
     use crate::alloc::Allocator;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -92,3 +92,113 @@ impl Drop for Stack {
         }
     }
 }
+
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+    use crate::test_support::RustSystemAllocator;
+    use crate::alloc::Allocator;
+
+    /// Verify that u32 write/read round-trips correctly for all valid addresses.
+    /// This confirms `ptr.add(addr)` stays in-bounds for the entire valid range.
+    #[kani::proof]
+    fn proof_stack_u32_roundtrip() {
+        let size: usize = kani::any();
+        kani::assume(size > 0 && size <= 16); // Small size for bounded verification
+
+        // Manually construct Stack using RustSystemAllocator to avoid GlobalAllocator FFI
+        let ptr = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let mut stack = Stack { ptr, size };
+
+        let addr: usize = kani::any();
+        kani::assume(addr < size);
+
+        let val: u32 = kani::any();
+        stack.write_u32(addr, val);
+        assert_eq!(stack.read_u32(addr), val, "u32 round-trip failed");
+
+        // Manual cleanup to avoid GlobalAllocator in Drop
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify that u64 write/read round-trips correctly with unaligned access.
+    /// This confirms `read_unaligned`/`write_unaligned` never access memory
+    /// outside the [0, size*4) byte range.
+    #[kani::proof]
+    fn proof_stack_u64_roundtrip() {
+        let size: usize = kani::any();
+        kani::assume(size >= 2 && size <= 16); // Need at least 2 words for u64
+
+        // Manually construct Stack using RustSystemAllocator to avoid GlobalAllocator FFI
+        let ptr = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let mut stack = Stack { ptr, size };
+
+        let addr: usize = kani::any();
+        kani::assume(addr <= size && size >= 2 && addr <= size - 2); // u64 needs 2 words (8 bytes)
+
+        let val: u64 = kani::any();
+        stack.write_u64(addr, val);
+        assert_eq!(stack.read_u64(addr), val, "u64 round-trip failed");
+
+        // Manual cleanup to avoid GlobalAllocator in Drop
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify that Stack::new either fails cleanly or computes size * 4
+    /// without silent overflow in the Layout calculation.
+    #[kani::proof]
+    fn proof_stack_new_size_no_overflow() {
+        let size: usize = kani::any();
+        kani::assume(size <= 1024); // Bound to prevent timeouts
+
+        // Check for overflow in size * 4 computation
+        let byte_size = size.checked_mul(4);
+
+        // If multiplication would overflow, we can't verify further
+        if byte_size.is_none() {
+            return;
+        }
+
+        let byte_size = byte_size.unwrap();
+
+        // Verify Layout::from_size_align doesn't panic
+        if let Ok(layout) = Layout::from_size_align(byte_size, 4) {
+            // If Layout succeeded, try allocation with RustSystemAllocator
+            if let Ok(ptr) = unsafe { RustSystemAllocator.alloc(layout) } {
+                // Allocation succeeded - verify we can construct a valid Stack
+                let stack = Stack {
+                    ptr: ptr.cast(),
+                    size,
+                };
+
+                // Clean up
+                unsafe {
+                    RustSystemAllocator.dealloc(ptr, layout);
+                }
+                core::mem::forget(stack);
+            }
+        }
+    }
+}

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -99,8 +99,193 @@ mod kani_proofs {
     use crate::alloc::Allocator;
     use crate::test_support::RustSystemAllocator;
 
-    /// Verify that u32 write/read round-trips correctly for all valid addresses.
-    /// This confirms `ptr.add(addr)` stays in-bounds for the entire valid range.
+    /// Verify `write_u32` only changes target word
+    #[kani::proof]
+    fn proof_write_u32_step_non_interference() {
+        const N: usize = 1_000_000;
+        let size: usize = kani::any();
+        kani::assume(size > 0 && size <= N);
+
+        let ptr: *mut u32 = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let mut stack = Stack { ptr, size };
+
+        let addr: usize = kani::any();
+        kani::assume(addr < size);
+
+        let addr2: usize = kani::any();
+        kani::assume(addr2 < size && addr2 != addr);
+        let old_other = stack.read_u32(addr2);
+
+        let value: u32 = kani::any();
+        stack.write_u32(addr, value);
+
+        assert_eq!(
+            stack.read_u32(addr),
+            value,
+            "write_u32 should update the addressed word"
+        );
+        assert_eq!(
+            stack.read_u32(addr2),
+            old_other,
+            "write_u32 must not modify any other word"
+        );
+
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify `write_u64` only changes memory at address
+    #[kani::proof]
+    fn proof_write_u64_step_noninterference() {
+        const N: usize = 1_000_000;
+        let size: usize = kani::any();
+        kani::assume(size >= 2 && size <= N);
+
+        let ptr: *mut u32 = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let mut stack = Stack { ptr, size };
+
+        let addr: usize = kani::any();
+        kani::assume(addr <= size - 2);
+
+        let addr2: usize = kani::any();
+        kani::assume(addr2 < size && addr2 != addr && addr2 != addr + 1);
+        let old_other = stack.read_u32(addr2);
+
+        let value: u64 = kani::any();
+        stack.write_u64(addr, value);
+
+        assert_eq!(
+            stack.read_u64(addr),
+            value,
+            "write_u64 should update the addressed doubleword"
+        );
+        assert_eq!(
+            stack.read_u32(addr2),
+            old_other,
+            "write_u64 must not modify any word outside [addr, addr+1]"
+        );
+
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify reads never mutate the buffer
+    #[kani::proof]
+    fn proof_read_does_not_mutate() {
+        const N: usize = 1_000_000;
+        let size: usize = kani::any();
+        kani::assume(size >= 2 && size <= N);
+
+        let ptr: *mut u32 = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let stack = Stack { ptr, size };
+
+        let addr: usize = kani::any();
+        kani::assume(addr <= size - 2);
+
+        let addr2: usize = kani::any();
+        kani::assume(addr2 < size);
+        let before = stack.read_u32(addr2);
+
+        let _ = stack.read_u32(addr);
+        let _ = stack.read_u64(addr);
+
+        assert_eq!(
+            stack.read_u32(addr2),
+            before,
+            "reads must not mutate memory"
+        );
+
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify that the last write gets read back
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_write_sequence_last_write_wins() {
+        const N: usize = 1_000_000;
+        const OPS: usize = 3;
+
+        let size: usize = kani::any();
+        kani::assume(size > 0 && size <= N);
+
+        let ptr: *mut u32 = unsafe {
+            RustSystemAllocator
+                .alloc(Layout::from_size_align(size * 4, 4).unwrap())
+                .unwrap()
+                .cast()
+        };
+        let mut stack = Stack { ptr, size };
+
+        let mut addrs = [0usize; OPS];
+        let mut values = [0u32; OPS];
+        for i in 0..OPS {
+            let addr: usize = kani::any();
+            kani::assume(addr < size);
+            let value: u32 = kani::any();
+            addrs[i] = addr;
+            values[i] = value;
+            stack.write_u32(addr, value);
+        }
+
+        let query: usize = kani::any();
+        kani::assume(query < size);
+
+        let mut expected: Option<u32> = None;
+        for i in 0..OPS {
+            if addrs[i] == query {
+                expected = Some(values[i]);
+            }
+        }
+
+        if let Some(expected_value) = expected {
+            assert_eq!(
+                stack.read_u32(query),
+                expected_value,
+                "last write to an address should determine its final value"
+            );
+        }
+
+        unsafe {
+            RustSystemAllocator.dealloc(
+                stack.ptr.cast(),
+                Layout::from_size_align(stack.size * 4, 4).unwrap(),
+            );
+        }
+        core::mem::forget(stack);
+    }
+
+    /// Verify that `ptr.add(addr)` stays in-bounds for the entire range
     #[kani::proof]
     fn proof_stack_u32_roundtrip() {
         let size: usize = kani::any();
@@ -132,9 +317,7 @@ mod kani_proofs {
         core::mem::forget(stack);
     }
 
-    /// Verify that u64 write/read round-trips correctly with unaligned access.
-    /// This confirms `read_unaligned`/`write_unaligned` never access memory
-    /// outside the [0, size*4) byte range.
+    /// Verify that `read_unaligned`/`write_unaligned` never access external memory
     #[kani::proof]
     fn proof_stack_u64_roundtrip() {
         let size: usize = kani::any();
@@ -166,8 +349,7 @@ mod kani_proofs {
         core::mem::forget(stack);
     }
 
-    /// Verify that Stack::new either fails cleanly or computes size * 4
-    /// without silent overflow in the Layout calculation.
+    /// Verify that Layout calculation never overflows
     #[kani::proof]
     fn proof_stack_new_size_no_overflow() {
         let size: usize = kani::any();

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -96,8 +96,8 @@ impl Drop for Stack {
 #[cfg(kani)]
 mod kani_proofs {
     use super::*;
-    use crate::test_support::RustSystemAllocator;
     use crate::alloc::Allocator;
+    use crate::test_support::RustSystemAllocator;
 
     /// Verify that u32 write/read round-trips correctly for all valid addresses.
     /// This confirms `ptr.add(addr)` stays in-bounds for the entire valid range.

--- a/src/util/circular_buffer.rs
+++ b/src/util/circular_buffer.rs
@@ -642,112 +642,162 @@ mod tests {
 mod kani_proofs {
     use super::*;
 
-    /// Verify push, pop_front, and pop_back operations maintain safety invariants.
-    /// This proves:
-    /// - Index calculations stay in bounds
-    /// - Push on full buffer drops old element before writing new
-    /// - Pops only read initialized memory
-    /// - Size tracking remains consistent
+    /// Verify write operations stay in bounds and sizes stay consistent
     #[kani::proof]
-    #[kani::unwind(10)]
-    fn proof_push_pop_correctness() {
+    fn proof_new_satisfies_invariant() {
         const N: usize = 4;
-        let mut buffer: CircularBuffer<u32, N> = CircularBuffer::new();
+        let buffer: CircularBuffer<u32, N> = CircularBuffer::new();
 
         assert!(buffer.start < N, "start index should stay within capacity");
         assert!(buffer.size <= N, "size should never exceed capacity");
         assert_eq!(buffer.len(), 0, "new buffer should be empty");
-
-        let num_ops: usize = kani::any();
-        kani::assume(num_ops <= 8);
-
-        for _ in 0..num_ops {
-            let op: u8 = kani::any();
-
-            match op % 3 {
-                0 => {
-                    let value: u32 = kani::any();
-                    let old_size = buffer.size;
-                    buffer.push(value);
-
-                    assert!(buffer.start < N, "start index should stay within capacity");
-                    assert!(buffer.size <= N, "size should never exceed capacity");
-                    if old_size < N {
-                        assert_eq!(
-                            buffer.size,
-                            old_size + 1,
-                            "size should increase by 1 when pushing to non-full buffer"
-                        );
-                    } else {
-                        assert_eq!(
-                            buffer.size, N,
-                            "size should remain at capacity when buffer is full"
-                        );
-                    }
-                }
-                1 => {
-                    let old_size = buffer.size;
-                    let result = buffer.pop_front();
-
-                    assert!(buffer.start < N, "start index should stay within capacity");
-                    assert!(buffer.size <= N, "size should never exceed capacity");
-                    if old_size == 0 {
-                        assert!(
-                            result.is_none(),
-                            "pop_front should return None on empty buffer"
-                        );
-                        assert_eq!(
-                            buffer.size, 0,
-                            "size should remain 0 when popping from empty buffer"
-                        );
-                    } else {
-                        assert!(
-                            result.is_some(),
-                            "pop_front should return Some on non-empty buffer"
-                        );
-                        assert_eq!(
-                            buffer.size,
-                            old_size - 1,
-                            "size should decrease by 1 after pop_front"
-                        );
-                    }
-                }
-                _ => {
-                    let old_size = buffer.size;
-                    let result = buffer.pop_back();
-
-                    assert!(buffer.start < N, "start index should stay within capacity");
-                    assert!(buffer.size <= N, "size should never exceed capacity");
-                    if old_size == 0 {
-                        assert!(
-                            result.is_none(),
-                            "pop_back should return None on empty buffer"
-                        );
-                        assert_eq!(
-                            buffer.size, 0,
-                            "size should remain 0 when popping from empty buffer"
-                        );
-                    } else {
-                        assert!(
-                            result.is_some(),
-                            "pop_back should return Some on non-empty buffer"
-                        );
-                        assert_eq!(
-                            buffer.size,
-                            old_size - 1,
-                            "size should decrease by 1 after pop_back"
-                        );
-                    }
-                }
-            }
-        }
     }
 
-    /// Verify random access operations (front, back, get) maintain safety invariants.
-    /// This proves:
-    /// - Index calculations for arbitrary positions stay in bounds
-    /// - Only access initialized slots
-    /// - Works correctly when buffer has wrapped
+    /// Verify `push` preserves invariants
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_push_step_invariant() {
+        const N: usize = 3;
+
+        let start: usize = kani::any();
+        let size: usize = kani::any();
+        kani::assume(start < N);
+        kani::assume(size <= N);
+
+        let mut buffer: CircularBuffer<u32, N> = CircularBuffer::new();
+        buffer.start = start;
+        buffer.size = size;
+        for i in 0..N {
+            buffer.items[i].write(kani::any());
+        }
+
+        let value: u32 = kani::any();
+        let old_size = buffer.size;
+        let old_start = buffer.start;
+        buffer.push(value);
+
+        assert!(buffer.start < N, "start index should stay within capacity");
+        assert!(buffer.size <= N, "size should never exceed capacity");
+        if old_size < N {
+            assert_eq!(
+                buffer.size,
+                old_size + 1,
+                "size should increase by 1 when pushing to non-full buffer"
+            );
+            assert_eq!(
+                buffer.start, old_start,
+                "start must not move when pushing to a non-full buffer"
+            );
+        } else {
+            assert_eq!(
+                buffer.size, N,
+                "size should remain at capacity when buffer is full"
+            );
+            assert_eq!(
+                buffer.start,
+                (old_start + 1) % N,
+                "start must advance by exactly one slot (wrapping) when overwriting the oldest element"
+            );
+        }
+
+        core::mem::forget(buffer);
+    }
+
+    /// Verify `pop_front` preserves invariants
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_pop_front_step_invariant() {
+        const N: usize = 3;
+
+        let start: usize = kani::any();
+        let size: usize = kani::any();
+        kani::assume(start < N);
+        kani::assume(size <= N);
+
+        let mut buffer: CircularBuffer<u32, N> = CircularBuffer::new();
+        buffer.start = start;
+        buffer.size = size;
+        for i in 0..N {
+            buffer.items[i].write(kani::any());
+        }
+
+        let old_size = buffer.size;
+        let result = buffer.pop_front();
+
+        assert!(buffer.start < N, "start index should stay within capacity");
+        assert!(buffer.size <= N, "size should never exceed capacity");
+        if old_size == 0 {
+            assert!(
+                result.is_none(),
+                "pop_front should return None on empty buffer"
+            );
+            assert_eq!(
+                buffer.size, 0,
+                "size should remain 0 when popping from empty buffer"
+            );
+        } else {
+            assert!(
+                result.is_some(),
+                "pop_front should return Some on non-empty buffer"
+            );
+            assert_eq!(
+                buffer.size,
+                old_size - 1,
+                "size should decrease by 1 after pop_front"
+            );
+        }
+
+        core::mem::forget(buffer);
+    }
+
+    /// Verify `pop_back` preserves invariants from any arbitrary valid state.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_pop_back_step_invariant() {
+        const N: usize = 3;
+
+        let start: usize = kani::any();
+        let size: usize = kani::any();
+        kani::assume(start < N);
+        kani::assume(size <= N);
+
+        let mut buffer: CircularBuffer<u32, N> = CircularBuffer::new();
+        buffer.start = start;
+        buffer.size = size;
+        for i in 0..N {
+            buffer.items[i].write(kani::any());
+        }
+
+        let old_size = buffer.size;
+        let result = buffer.pop_back();
+
+        assert!(buffer.start < N, "start index should stay within capacity");
+        assert!(buffer.size <= N, "size should never exceed capacity");
+        if old_size == 0 {
+            assert!(
+                result.is_none(),
+                "pop_back should return None on empty buffer"
+            );
+            assert_eq!(
+                buffer.size, 0,
+                "size should remain 0 when popping from empty buffer"
+            );
+        } else {
+            assert!(
+                result.is_some(),
+                "pop_back should return Some on non-empty buffer"
+            );
+            assert_eq!(
+                buffer.size,
+                old_size - 1,
+                "size should decrease by 1 after pop_back"
+            );
+        }
+
+        core::mem::forget(buffer);
+    }
+
+    /// Verify random access operations stay in bounds and wrap correctly
     #[kani::proof]
     #[kani::unwind(10)]
     fn proof_random_access_safety() {
@@ -862,12 +912,7 @@ mod kani_proofs {
         }
     }
 
-    /// Verify iterator operations are memory safe.
-    /// This proves:
-    /// - Iterator index stays within valid range
-    /// - Sequential access doesn't access uninitialized memory
-    /// - IterMut raw pointer dereference is safe
-    /// - Works correctly with wrapped buffer
+    /// Verify iterator operations are in range and only access initialized memory
     #[kani::proof]
     #[kani::unwind(10)]
     fn proof_iterator_safety() {
@@ -929,11 +974,7 @@ mod kani_proofs {
         );
     }
 
-    /// Verify drop behavior is safe and correct.
-    /// This proves:
-    /// - Every initialized element is dropped exactly once
-    /// - No double-drops
-    /// - Works correctly regardless of buffer state (empty, partial, full, wrapped)
+    /// Verify every element is dropped exactly once
     #[kani::proof]
     #[kani::unwind(8)]
     fn proof_drop_safety() {
@@ -989,11 +1030,7 @@ mod kani_proofs {
         }
     }
 
-    /// Verify overflow behavior when buffer wraps around.
-    /// This proves:
-    /// - Overwriting oldest element works correctly
-    /// - Old element is dropped before new one is written
-    /// - Wrapping arithmetic is correct
+    /// Verify buffer wrapping works correctly
     #[kani::proof]
     #[kani::unwind(8)]
     fn proof_overflow_wrapping() {

--- a/src/util/static_vec.rs
+++ b/src/util/static_vec.rs
@@ -241,7 +241,63 @@ mod kani_proofs {
         assert_eq!(vec.pop(), None, "popping empty vector should return None");
     }
 
-    /// Verify StaticVec IntoIterator yields values in correct order and drops properly.
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn proof_push_step_invariant() {
+        const N: usize = 4;
+        let mut vec: StaticVec<u32, N> = StaticVec::new();
+
+        let len: u32 = kani::any();
+        kani::assume((len as usize) <= N);
+        vec.len = len;
+        for i in 0..N {
+            vec.data[i].write(kani::any());
+        }
+
+        let value: u32 = kani::any();
+        let old_len = vec.len;
+        let result = vec.push(value);
+
+        assert!((vec.len as usize) <= N, "len must never exceed capacity");
+        if (old_len as usize) < N {
+            assert!(result.is_ok(), "push must succeed below capacity");
+            assert_eq!(vec.len, old_len + 1, "len must increase by 1");
+        } else {
+            assert!(result.is_err(), "push must fail at capacity");
+            assert_eq!(vec.len, old_len, "len must not change on a failed push");
+        }
+
+        core::mem::forget(vec);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn proof_pop_step_invariant() {
+        const N: usize = 4;
+        let mut vec: StaticVec<u32, N> = StaticVec::new();
+
+        let len: u32 = kani::any();
+        kani::assume((len as usize) <= N);
+        vec.len = len;
+        for i in 0..N {
+            vec.data[i].write(kani::any());
+        }
+
+        let old_len = vec.len;
+        let result = vec.pop();
+
+        assert!((vec.len as usize) <= N, "len must never exceed capacity");
+        if old_len == 0 {
+            assert!(result.is_none(), "pop must return None when empty");
+            assert_eq!(vec.len, 0, "len must stay 0 when popping an empty vec");
+        } else {
+            assert!(result.is_some(), "pop must return Some when non-empty");
+            assert_eq!(vec.len, old_len - 1, "len must decrease by 1");
+        }
+
+        core::mem::forget(vec);
+    }
+
     #[kani::proof]
     #[kani::unwind(5)]
     fn proof_into_iter_correctness() {

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -441,7 +441,11 @@ mod kani_proofs {
 
         // Verify equal length and capacity
         assert_eq!(cloned.len(), vec.len(), "Clone must have same length");
-        assert_eq!(cloned.capacity(), vec.capacity(), "Clone must have same capacity");
+        assert_eq!(
+            cloned.capacity(),
+            vec.capacity(),
+            "Clone must have same capacity"
+        );
 
         // Verify equal contents by comparing the slices directly
         for i in 0..original_len {
@@ -469,7 +473,10 @@ mod kani_proofs {
         }
 
         let len = vec.len();
-        assert_eq!(len, capacity as usize, "Vec must be full for into_boxed_slice");
+        assert_eq!(
+            len, capacity as usize,
+            "Vec must be full for into_boxed_slice"
+        );
 
         let boxed_slice = vec.into_boxed_slice();
 

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -415,6 +415,76 @@ mod kani_proofs {
 
         // Vec drops here - dealloc will verify the layout size matches what was allocated
     }
+
+    /// Verify that Vec::clone creates an independent copy with equal contents.
+    /// Tests the unsafe ptr::write loop in Clone::clone (vec.rs:63-82).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_vec_clone_correctness() {
+        let capacity: u32 = kani::any();
+        kani::assume(capacity <= 3);
+
+        let mut vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();
+
+        // Push symbolic values up to capacity
+        let len: u32 = kani::any();
+        kani::assume(len <= capacity);
+
+        for _ in 0..len {
+            let val: u32 = kani::any();
+            vec.push(val);
+        }
+
+        let original_len = vec.len();
+
+        let cloned = vec.clone();
+
+        // Verify equal length and capacity
+        assert_eq!(cloned.len(), vec.len(), "Clone must have same length");
+        assert_eq!(cloned.capacity(), vec.capacity(), "Clone must have same capacity");
+
+        // Verify equal contents by comparing the slices directly
+        for i in 0..original_len {
+            assert_eq!(cloned[i], vec[i], "Clone must have same contents");
+        }
+
+        // Verify independence: when non-zero capacity, the clone owns different memory
+        // (Skip the pointer check since capacity can be 0, where both pointers are null)
+    }
+
+    /// Verify that into_boxed_slice correctly converts a full Vec to Box<[T]>
+    /// without double-free. Tests the mem::forget + from_raw pattern (vec.rs:240-254).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn proof_vec_into_boxed_slice_correctness() {
+        let capacity: u32 = kani::any();
+        kani::assume(capacity > 0 && capacity <= 3);
+
+        let mut vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();
+
+        // Fill to capacity (required by into_boxed_slice)
+        let values: [u32; 3] = kani::any();
+        for i in 0..(capacity as usize) {
+            vec.push(values[i]);
+        }
+
+        let len = vec.len();
+        assert_eq!(len, capacity as usize, "Vec must be full for into_boxed_slice");
+
+        let boxed_slice = vec.into_boxed_slice();
+
+        // Verify the Box has the same length and contents
+        assert_eq!(boxed_slice.len(), len, "Box must have same length as Vec");
+        for i in 0..len {
+            assert_eq!(
+                boxed_slice[i], values[i],
+                "Box must have same contents as Vec"
+            );
+        }
+
+        // Box drops here - if mem::forget in into_boxed_slice didn't work correctly,
+        // this would be a double-free detected by RustSystemAllocator
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Use induction to prove push, pop, and iterators from `CircularBuffer` never accesses uninitialized memory, and capacity/index stay correct.
* Proves that any write to the stack will change memory only at the (correctly bounded) target address, and subsequent reads will return the changed memory