### PR TITLE
Add validate differential fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,7 +1444,9 @@ dependencies = [
  "log",
  "spacewasm",
  "wasm-smith",
+ "wasmi",
  "wasmprinter",
+ "wat",
 ]
 
 [[package]]
@@ -1469,10 +1477,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -1664,6 +1688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
 name = "wasm-smith"
 version = "0.220.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,7 +1825,48 @@ dependencies = [
  "flagset",
  "indexmap",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.220.1",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+ "wat",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
 ]
 
 [[package]]
@@ -1809,6 +1890,27 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1964,6 +2066,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "256.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.256.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
+dependencies = [
+ "wast 256.0.0",
 ]
 
 [[package]]
@@ -2230,7 +2354,7 @@ dependencies = [
  "anyhow",
  "log",
  "thiserror 1.0.69",
- "wast",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fuzz fuzz-validate fuzz-malformed seed-to-wasm trace-wasm trace trace-debug clean-artifacts install-tools
+.PHONY: help fuzz fuzz-validate fuzz-validate-differential fuzz-malformed seed-to-wasm trace-wasm trace trace-debug clean-artifacts install-tools
 
 # Target Configuration (auto-detect if not set)
 SPACEWASM_TARGET ?= $(shell rustc -vV | grep 'host:' | cut -d' ' -f2)
@@ -13,6 +13,7 @@ help:
 	@echo "Fuzzing:"
 	@echo "  make fuzz                          Run the no_traps fuzzer"
 	@echo "  make fuzz-validate                 Run the validate fuzzer"
+	@echo "  make fuzz-validate-differential    Run the validate differential fuzzer (SpaceWasm vs wasmi)"
 	@echo "  make fuzz-malformed                Run the malformed-input decoder fuzzer"
 	@echo ""
 	@echo "Crash Analysis:"
@@ -37,6 +38,9 @@ fuzz:
 
 fuzz-validate:
 	cargo +nightly fuzz run validate --target $(SPACEWASM_TARGET)
+
+fuzz-validate-differential:
+	cargo +nightly fuzz run validate_differential --target $(SPACEWASM_TARGET)
 
 fuzz-malformed:
 	cargo +nightly fuzz run malformed --target $(SPACEWASM_TARGET)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ and [wasm-smith](https://github.com/bytecodealliance/wasm-tools/tree/main/crates
 # Run fuzzer
 make fuzz
 
+# Differentially test the validator against wasmi (SpaceWasm vs a reference)
+make fuzz-validate-differential
+
 # Analyze crashes with execution traces
 make trace CRASH=fuzz/artifacts/no_traps/crash-xxx
 ```

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -11,3 +11,11 @@ log = "0.4"
 wasm-smith = "0.220.0"
 wasmprinter = "0.220.0"
 env_logger = "0.11"
+wasmi = { version = "1", optional = true }
+
+[features]
+# Differential validator testing against wasmi as a reference implementation.
+differential = ["dep:wasmi"]
+
+[dev-dependencies]
+wat = "1"

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -237,7 +237,8 @@ fn load_module(wasm: &[u8]) -> bool {
 /// not. The fuzzer's configured limits funnel here: the code-page, control-frame,
 /// and operand-stack bounds surface as `AllocError`; oversized decoded vectors as
 /// `VecTooLong`; over-range branch offsets as `LabelJumpTooLarge`; the 16-bit
-/// local cap as `TooManyLocals`.
+/// local cap as `TooManyLocals`; and a table larger than `MAX_TABLE_ELEMENTS`
+/// (10M, well under the spec's 2^32-1) as `TableTooLarge`.
 ///
 /// **Instantiation-time checks.** SpaceWasm's `Module::new` decodes, validates,
 /// *and* instantiates in one pass (it allocates guest memory and eagerly
@@ -249,17 +250,19 @@ fn load_module(wasm: &[u8]) -> bool {
 /// out-of-bounds active data segments (`InvalidNegativeMemOffset`, or a
 /// `MemoryError` from the eager memory write).
 ///
-/// **wasmi feature-gating leniency.** SpaceWasm enforces the MVP section set
-/// strictly, but wasmi -- even with the corresponding proposal disabled -- accepts
-/// a `DataCount` section (id 12, from the bulk-memory proposal); its parser does
-/// not gate the section's mere presence. SpaceWasm rightly rejects it as
-/// `MalformedSectionId(12)`, and there is no wasmi config knob to match.
+/// **wasmi feature-gating leniency.** wasmi -- even with the bulk-memory proposal
+/// disabled -- accepts encodings SpaceWasm's strict MVP decoder rejects: a
+/// `DataCount` section (id 12) surfaces as `MalformedSectionId(12)`, and a data
+/// segment using the bulk-memory flag byte (`0x01` passive / `0x02` explicit
+/// memidx) is read by SpaceWasm as a nonzero memory index, surfacing as
+/// `InvalidMemIndex`. wasmi does not gate these on the feature flag, and there is
+/// no wasmi config knob to match.
 ///
 /// Variant granularity is sound here because this classifier is only consulted
 /// when wasmi *accepted* the module: the validation-error subcases that share
-/// these variants (e.g. a non-`i32` element/data offset expression, or an
-/// unknown section id other than 12) make wasmi reject too, so they never reach
-/// this check.
+/// these variants (e.g. a non-`i32` element/data offset expression, an unknown
+/// section id other than 12, or an export of a nonexistent memory index) make
+/// wasmi reject too, so they never reach this check.
 #[cfg(feature = "differential")]
 fn is_benign_rejection(err: &ValidationError) -> bool {
     matches!(
@@ -269,14 +272,17 @@ fn is_benign_rejection(err: &ValidationError) -> bool {
             | ValidationError::VecTooLong
             | ValidationError::LabelJumpTooLarge
             | ValidationError::TooManyLocals
+            | ValidationError::TableTooLarge
             // Instantiation-time checks (deferred past validation by the spec).
             | ValidationError::MemoryError(_)
             | ValidationError::GuestMemoryAllocationFailure
             | ValidationError::InvalidElementOffset
             | ValidationError::InvalidElementOutOfBounds
             | ValidationError::InvalidNegativeMemOffset
-            // wasmi feature-gating leniency: DataCount section (bulk-memory).
+            // wasmi feature-gating leniency (bulk-memory encodings it accepts
+            // even with the proposal disabled).
             | ValidationError::MalformedSectionId(12)
+            | ValidationError::InvalidMemIndex
     )
 }
 
@@ -750,6 +756,55 @@ mod validate_differential_tests {
         .is_ok()));
 
         // They disagree, but the oracle must stay quiet (no panic).
+        validate_differential(&wasm);
+    }
+
+    /// Regression: a table larger than `MAX_TABLE_ELEMENTS` (10M) is within the
+    /// Wasm spec's 2^32-1 limit, so wasmi accepts it, but exceeds SpaceWasm's
+    /// embedded cap. That resource-limit rejection must be filtered out of the
+    /// completeness direction. This case was found by the fuzzer.
+    #[test]
+    fn validate_ignores_oversized_table_limit() {
+        let wasm = wat::parse_str(r#"(module (table 16400383 funcref))"#).unwrap();
+
+        let err = validate_module(&wasm).expect_err("table exceeds the embedded cap");
+        assert_eq!(err, ValidationError::TableTooLarge);
+        assert!(is_benign_rejection(&err));
+
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
+        validate_differential(&wasm);
+    }
+
+    /// Regression: a data segment encoded with the bulk-memory flag byte `0x02`
+    /// (active, explicit memidx) is accepted by wasmi even with bulk memory
+    /// disabled, but SpaceWasm's MVP decoder reads the flag as the memory index
+    /// and rejects it as `InvalidMemIndex`. That wasmi feature-gating leniency
+    /// must be filtered out of the completeness direction. Built as raw bytes
+    /// because `wat` will not emit the bulk-memory encoding for an MVP module.
+    /// This case was found by the fuzzer.
+    #[test]
+    fn validate_ignores_wasmi_bulk_data_flag_leniency() {
+        let wasm = [
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+            0x05, 0x03, 0x01, 0x00, 0x01, // memory: 1 memory, min 1 page
+            // data section: 1 segment, flag 0x02 (active + explicit memidx),
+            // memidx 0, offset (i32.const 0) (end), 0 bytes.
+            0x0b, 0x07, 0x01, 0x02, 0x00, 0x41, 0x00, 0x0b, 0x00,
+        ];
+
+        let err = validate_module(&wasm).expect_err("bulk-memory data flag is not MVP");
+        assert_eq!(err, ValidationError::InvalidMemIndex);
+        assert!(is_benign_rejection(&err));
+
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
         validate_differential(&wasm);
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -532,7 +532,7 @@ mod validate_differential_tests {
         let garbage = [0x00u8, 0x61, 0x73, 0x6d, 0xff, 0xff, 0xff, 0xff, 0x13, 0x37];
         validate_differential(&garbage);
         assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(
-            e, &garbage
+            e, garbage
         )
         .is_ok()));
 

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -237,8 +237,9 @@ fn load_module(wasm: &[u8]) -> bool {
 /// not. The fuzzer's configured limits funnel here: the code-page, control-frame,
 /// and operand-stack bounds surface as `AllocError`; oversized decoded vectors as
 /// `VecTooLong`; over-range branch offsets as `LabelJumpTooLarge`; the 16-bit
-/// local cap as `TooManyLocals`; and a table larger than `MAX_TABLE_ELEMENTS`
-/// (10M, well under the spec's 2^32-1) as `TableTooLarge`.
+/// local cap as `TooManyLocals`; a table larger than `MAX_TABLE_ELEMENTS`
+/// (10M, well under the spec's 2^32-1) as `TableTooLarge`; and a function with
+/// more than 255 parameter slots as `FunctionParametersTooLarge`.
 ///
 /// **Instantiation-time checks.** SpaceWasm's `Module::new` decodes, validates,
 /// *and* instantiates in one pass (it allocates guest memory and eagerly
@@ -273,6 +274,7 @@ fn is_benign_rejection(err: &ValidationError) -> bool {
             | ValidationError::LabelJumpTooLarge
             | ValidationError::TooManyLocals
             | ValidationError::TableTooLarge
+            | ValidationError::FunctionParametersTooLarge
             // Instantiation-time checks (deferred past validation by the spec).
             | ValidationError::MemoryError(_)
             | ValidationError::GuestMemoryAllocationFailure
@@ -769,6 +771,29 @@ mod validate_differential_tests {
 
         let err = validate_module(&wasm).expect_err("table exceeds the embedded cap");
         assert_eq!(err, ValidationError::TableTooLarge);
+        assert!(is_benign_rejection(&err));
+
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
+        validate_differential(&wasm);
+    }
+
+    /// Regression: a function type with more than 255 parameter slots is valid
+    /// per the Wasm spec (wasmi accepts it), but exceeds SpaceWasm's embedded
+    /// parameter cap and is rejected as `FunctionParametersTooLarge`. That
+    /// resource-limit rejection must be filtered out of the completeness
+    /// direction rather than reported as a divergence.
+    #[test]
+    fn validate_ignores_oversized_function_params() {
+        // 300 i32 params = 300 four-byte slots, past the 255-slot cap.
+        let params = "i32 ".repeat(300);
+        let wasm = wat::parse_str(&format!(r#"(module (func (param {params})))"#)).unwrap();
+
+        let err = validate_module(&wasm).expect_err("param count exceeds the embedded cap");
+        assert_eq!(err, ValidationError::FunctionParametersTooLarge);
         assert!(is_benign_rejection(&err));
 
         assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -179,23 +179,21 @@ const MAX_CODE_PAGES: u32 = 128;
 const MAX_CONTROL_FRAMES: usize = 128;
 const MAX_STACK_DEPTH: usize = 256;
 
-/// Decode and validate a Wasm module, discarding the outcome.
+/// Decode and validate a Wasm module, returning SpaceWasm's classified outcome.
 ///
-/// Both `Ok` and `Err` are acceptable results: a graceful decode error is a
-/// correct rejection, not a bug. The only failures this surfaces are *implicit*
-/// -- a `panic!` (including the `strict-assertions` checks), an abort, a
-/// segfault, or a sanitizer trip during `Module::new`. libFuzzer treats all of
-/// those as crashes.
+/// `Ok(())` means SpaceWasm accepted the module; `Err(validation_error)` is a
+/// graceful rejection carrying the concrete [`ValidationError`] so callers can
+/// classify *why* SpaceWasm refused it (see [`is_benign_rejection`]). Neither is a
+/// bug on its own. The only failures this surfaces implicitly are a `panic!`
+/// (including the `strict-assertions` checks), an abort, a segfault, or a
+/// sanitizer trip during `Module::new`; libFuzzer treats those as crashes.
 ///
-/// Returns `true` if decoding succeeded, for callers that want to log it.
-fn load_module(wasm: &[u8]) -> bool {
-    let mut store = match Store::from_host_modules(256, Vec::zero()) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!("store creation failed: {e:?}");
-            return false;
-        }
-    };
+/// Store and `CodeBuilder` setup use fixed sizes independent of the fuzz input,
+/// so a failure there is an infrastructure problem, not a module rejection --
+/// hence the `.expect(...)`s rather than a spurious `Err`.
+fn validate_module(wasm: &[u8]) -> Result<(), ValidationError> {
+    let mut store =
+        Store::from_host_modules(256, Vec::zero()).expect("fuzz store creation must not fail");
 
     let mut code_builder = CodeBuilder::new(CompilerOptions {
         allow_memory_grow: true,
@@ -209,16 +207,77 @@ fn load_module(wasm: &[u8]) -> bool {
         .unwrap()
         .into_wasm_memory_allocator();
 
-    // Attempt to decode and validate the module.
-    let result = Module::new::<MAX_CONTROL_FRAMES, MAX_STACK_DEPTH>(
+    // Attempt to decode and validate the module. `ParseError` wraps a
+    // `SectionDecodeError`, which in turn carries the innermost `ValidationError`.
+    Module::new::<MAX_CONTROL_FRAMES, MAX_STACK_DEPTH>(
         "",
         &mut stream,
         &mut store,
         &mut code_builder,
         allocator.clone(),
-    );
+    )
+    .map(|_| ())
+    .map_err(|e: ParseError| e.err.err)
+}
 
-    result.is_ok()
+/// Decode and validate a Wasm module, discarding the outcome.
+///
+/// Returns `true` if decoding succeeded, for callers that only need the
+/// accept/reject bit (see [`validate_module`] for the classified variant).
+fn load_module(wasm: &[u8]) -> bool {
+    validate_module(wasm).is_ok()
+}
+
+/// Rejections that are *not* evidence of a SpaceWasm validation-completeness bug,
+/// even though wasmi's validator accepted the same module. The completeness
+/// direction of [`validate_differential`] must not treat these as divergences.
+/// They fall into three groups:
+///
+/// **Embedded resource limits.** SpaceWasm bounds what a general validator does
+/// not. The fuzzer's configured limits funnel here: the code-page, control-frame,
+/// and operand-stack bounds surface as `AllocError`; oversized decoded vectors as
+/// `VecTooLong`; over-range branch offsets as `LabelJumpTooLarge`; the 16-bit
+/// local cap as `TooManyLocals`.
+///
+/// **Instantiation-time checks.** SpaceWasm's `Module::new` decodes, validates,
+/// *and* instantiates in one pass (it allocates guest memory and eagerly
+/// initializes tables and data), whereas `wasmi::Module::validate` only validates.
+/// Conditions the Wasm MVP spec defers to instantiation therefore make SpaceWasm
+/// reject at load while wasmi's validator accepts: guest-memory allocation
+/// (`GuestMemoryAllocationFailure`, bounded to 64 MiB here), out-of-bounds active
+/// element segments (`InvalidElementOffset`, `InvalidElementOutOfBounds`), and
+/// out-of-bounds active data segments (`InvalidNegativeMemOffset`, or a
+/// `MemoryError` from the eager memory write).
+///
+/// **wasmi feature-gating leniency.** SpaceWasm enforces the MVP section set
+/// strictly, but wasmi -- even with the corresponding proposal disabled -- accepts
+/// a `DataCount` section (id 12, from the bulk-memory proposal); its parser does
+/// not gate the section's mere presence. SpaceWasm rightly rejects it as
+/// `MalformedSectionId(12)`, and there is no wasmi config knob to match.
+///
+/// Variant granularity is sound here because this classifier is only consulted
+/// when wasmi *accepted* the module: the validation-error subcases that share
+/// these variants (e.g. a non-`i32` element/data offset expression, or an
+/// unknown section id other than 12) make wasmi reject too, so they never reach
+/// this check.
+#[cfg(feature = "differential")]
+fn is_benign_rejection(err: &ValidationError) -> bool {
+    matches!(
+        err,
+        // Embedded resource limits.
+        ValidationError::AllocError(_)
+            | ValidationError::VecTooLong
+            | ValidationError::LabelJumpTooLarge
+            | ValidationError::TooManyLocals
+            // Instantiation-time checks (deferred past validation by the spec).
+            | ValidationError::MemoryError(_)
+            | ValidationError::GuestMemoryAllocationFailure
+            | ValidationError::InvalidElementOffset
+            | ValidationError::InvalidElementOutOfBounds
+            | ValidationError::InvalidNegativeMemOffset
+            // wasmi feature-gating leniency: DataCount section (bulk-memory).
+            | ValidationError::MalformedSectionId(12)
+    )
 }
 
 /// Oracle: Validate a Wasm module.
@@ -478,17 +537,18 @@ fn with_wasmi_validate_engine<R>(f: impl FnOnce(&wasmi::Engine) -> R) -> R {
 /// Oracle: differentially test the *validator*.
 ///
 /// Decodes+validates the same bytes with both engines and checks the accept /
-/// reject decisions. We assert only the **soundness** direction: if SpaceWasm
-/// *accepts* a module that wasmi (a conformant validator with a matched feature
-/// set) *rejects* as invalid, that is a potential soundness bug -- SpaceWasm
-/// admitting a module it should have refused -- and is reported by panicking.
+/// reject decisions against wasmi (a conformant validator with a matched feature
+/// set). Both directions are asserted:
 ///
-/// The reverse direction (SpaceWasm rejects what wasmi accepts) is intentionally
-/// **not** flagged: SpaceWasm is an embedded engine with stricter resource
-/// limits (bounded code pages, control-frame and operand-stack depth, allocation
-/// size), so it legitimately rejects large-but-valid modules that wasmi accepts.
-/// Distinguishing those limit rejections from true completeness bugs needs error
-/// classification and is left to a future refinement.
+/// * **Soundness** -- SpaceWasm *accepts* what wasmi *rejects*: a module SpaceWasm
+///   should have refused. Reported by panicking.
+/// * **Completeness** -- SpaceWasm *rejects* what wasmi *accepts*: a module
+///   SpaceWasm should have admitted. Reported by panicking, *unless* the rejection
+///   is not a Wasm-validation failure ([`is_benign_rejection`]) -- an
+///   embedded resource limit, or an instantiation-time check that SpaceWasm's
+///   combined decode+validate+instantiate pass performs at load but the spec (and
+///   thus wasmi's validator) defers. Those rejections are legitimate and filtered
+///   out rather than flagged.
 ///
 /// Best driven with the [`crate::generators::MalformedModule`] generator, whose
 /// byte-level mutations of valid modules densely exercise the accept/reject
@@ -497,16 +557,35 @@ fn with_wasmi_validate_engine<R>(f: impl FnOnce(&wasmi::Engine) -> R) -> R {
 pub fn validate_differential(wasm: &[u8]) {
     crate::init_fuzzing();
 
-    // `load_module` runs SpaceWasm's full decode + validate and returns whether
-    // it accepted the module.
-    let space_ok = load_module(wasm);
-    let wasmi_ok = with_wasmi_validate_engine(|engine| wasmi::Module::new(engine, wasm).is_ok());
+    // `validate_module` runs SpaceWasm's full decode + validate and reports
+    // whether it accepted the module, and if not, the concrete rejection reason.
+    let space_result = validate_module(wasm);
+    // Use `Module::validate`, not `Module::new`: the latter compiles lazily by
+    // default and defers (or skips) validation for inputs it never fully parses,
+    // so it leniently reports `Ok` on truncated/headerless garbage that is not
+    // actually valid. `validate` eagerly validates the whole module, matching
+    // what SpaceWasm's decoder does.
+    let wasmi_ok =
+        with_wasmi_validate_engine(|engine| wasmi::Module::validate(engine, wasm).is_ok());
 
-    if space_ok && !wasmi_ok {
-        log_wasm(wasm);
-        panic!(
-            "validation soundness divergence: SpaceWasm accepted a module that wasmi rejected as invalid"
-        );
+    match space_result {
+        // Soundness: SpaceWasm accepted a module wasmi rejects as invalid.
+        Ok(()) if !wasmi_ok => {
+            log_wasm(wasm);
+            panic!(
+                "validation soundness divergence: SpaceWasm accepted a module that wasmi rejected as invalid"
+            );
+        }
+        // Completeness: SpaceWasm rejected -- for a genuine validation reason, not
+        // a resource limit or instantiation-time check -- a module wasmi accepts.
+        Err(err) if wasmi_ok && !is_benign_rejection(&err) => {
+            log_wasm(wasm);
+            panic!(
+                "validation completeness divergence: SpaceWasm rejected ({err:?}) a module that wasmi accepted as valid"
+            );
+        }
+        // Agreement, or an allow-listed resource-limit rejection: not a bug.
+        _ => {}
     }
 }
 
@@ -523,7 +602,7 @@ mod validate_differential_tests {
         // Both accept -> no panic.
         validate_differential(&valid);
         assert!(load_module(&valid));
-        assert!(with_wasmi_validate_engine(|e| wasmi::Module::new(
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
             e, &valid
         )
         .is_ok()));
@@ -531,8 +610,8 @@ mod validate_differential_tests {
         // Random garbage: both reject -> no panic, and neither validator accepts.
         let garbage = [0x00u8, 0x61, 0x73, 0x6d, 0xff, 0xff, 0xff, 0xff, 0x13, 0x37];
         validate_differential(&garbage);
-        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(
-            e, garbage
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &garbage
         )
         .is_ok()));
 
@@ -544,9 +623,133 @@ mod validate_differential_tests {
         .unwrap();
         validate_differential(&multi);
         assert!(!load_module(&multi));
-        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::validate(
             e, &multi
         )
         .is_ok()));
+    }
+
+    /// A spec-valid module that trips one of SpaceWasm's embedded resource limits
+    /// must be filtered out of the completeness direction, not reported as a
+    /// divergence. Here the operand stack is grown past `MAX_STACK_DEPTH` (256)
+    /// with a run of `i32.const`s that are then dropped, so the function is valid
+    /// per spec (wasmi accepts) but SpaceWasm rejects with an `AllocError` when
+    /// its fixed-size operand stack overflows.
+    #[test]
+    fn validate_ignores_resource_limit_rejections() {
+        // Push more values than the operand-stack bound, then drop them all so the
+        // function's result type is empty and the module stays spec-valid.
+        let depth = MAX_STACK_DEPTH + 64;
+        let mut body = String::new();
+        for _ in 0..depth {
+            body.push_str("i32.const 0 ");
+        }
+        for _ in 0..depth {
+            body.push_str("drop ");
+        }
+        let wasm = wat::parse_str(format!(r#"(module (func (export "f") {body}))"#)).unwrap();
+
+        // SpaceWasm rejects, and the rejection is an allow-listed resource limit.
+        let err = validate_module(&wasm).expect_err("operand stack must overflow the limit");
+        assert!(
+            is_benign_rejection(&err),
+            "expected a resource-limit rejection, got {err:?}"
+        );
+
+        // wasmi accepts the same module as valid.
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
+        // The two therefore disagree, but the oracle must stay quiet (no panic).
+        validate_differential(&wasm);
+    }
+
+    /// Regression: a short, header-less blob is invalid and both validators must
+    /// reject it. wasmi's lazily-compiling `Module::new` leniently reports `Ok`
+    /// here (it never fully parses the input), which would spuriously trip the
+    /// completeness direction; `Module::validate` -- what the oracle uses -- does
+    /// not. This case was found by the fuzzer.
+    #[test]
+    fn validate_rejects_headerless_blob_like_wasmi_validate() {
+        let blob = [10u8, 10, 40, 64, 37, 41];
+
+        // SpaceWasm rejects (no `\0asm` magic).
+        assert_eq!(validate_module(&blob), Err(ValidationError::MalformedMagic));
+
+        // wasmi's eager validator also rejects it...
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &blob
+        )
+        .is_ok()));
+        // ...even though its lazy `Module::new` leniently accepts it.
+        assert!(with_wasmi_validate_engine(
+            |e| wasmi::Module::new(e, blob).is_ok()
+        ));
+
+        // Both reject -> the oracle stays quiet.
+        validate_differential(&blob);
+    }
+
+    /// Regression: an active element segment whose offset lies past the table's
+    /// size is *valid* per the Wasm MVP spec (it fails at instantiation, which a
+    /// pure validator like wasmi does not perform), but SpaceWasm's combined
+    /// decode+validate+instantiate pass rejects it eagerly at load. That
+    /// instantiation-time rejection must be filtered out of the completeness
+    /// direction rather than reported as a divergence. This class of divergence
+    /// was found by the fuzzer.
+    #[test]
+    fn validate_ignores_instantiation_time_rejections() {
+        // Table holds 1 element; the element segment targets offset 5 -> out of
+        // bounds at instantiation, but structurally valid.
+        let wasm =
+            wat::parse_str(r#"(module (func) (table 1 funcref) (elem (i32.const 5) 0))"#).unwrap();
+
+        // SpaceWasm rejects with an instantiation-time check that is filtered out.
+        let err = validate_module(&wasm).expect_err("element segment is out of bounds");
+        assert_eq!(err, ValidationError::InvalidElementOffset);
+        assert!(is_benign_rejection(&err));
+
+        // wasmi's validator accepts it (the spec defers the bounds check).
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
+        // They disagree, but the oracle must stay quiet (no panic).
+        validate_differential(&wasm);
+    }
+
+    /// Regression: a `DataCount` section (id 12, from the bulk-memory proposal) is
+    /// not part of the Wasm MVP, so SpaceWasm rejects it as `MalformedSectionId(12)`.
+    /// wasmi accepts it even with bulk memory disabled -- its parser does not gate
+    /// the section's presence -- so this feature-gating leniency must be filtered
+    /// out of the completeness direction. This case was found by the fuzzer.
+    #[test]
+    fn validate_ignores_wasmi_datacount_leniency() {
+        // A minimal MVP module (one `() -> ()` function) with a `DataCount 0`
+        // section spliced in before the code section.
+        let wasm = [
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+            0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type: () -> ()
+            0x03, 0x02, 0x01, 0x00, // function: 1 func, type 0
+            0x0c, 0x01, 0x00, // DataCount section (id 12), value 0
+            0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b, // code: 1 func, empty body
+        ];
+
+        // SpaceWasm rejects the post-MVP section; the rejection is filtered out.
+        let err = validate_module(&wasm).expect_err("DataCount is not an MVP section");
+        assert_eq!(err, ValidationError::MalformedSectionId(12));
+        assert!(is_benign_rejection(&err));
+
+        // wasmi accepts it despite `wasm_bulk_memory(false)`.
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::validate(
+            e, &wasm
+        )
+        .is_ok()));
+
+        // They disagree, but the oracle must stay quiet (no panic).
+        validate_differential(&wasm);
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -790,7 +790,7 @@ mod validate_differential_tests {
     fn validate_ignores_oversized_function_params() {
         // 300 i32 params = 300 four-byte slots, past the 255-slot cap.
         let params = "i32 ".repeat(300);
-        let wasm = wat::parse_str(&format!(r#"(module (func (param {params})))"#)).unwrap();
+        let wasm = wat::parse_str(format!(r#"(module (func (param {params})))"#)).unwrap();
 
         let err = validate_module(&wasm).expect_err("param count exceeds the embedded cap");
         assert_eq!(err, ValidationError::FunctionParametersTooLarge);

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -437,3 +437,107 @@ pub fn no_traps(wasm: &[u8]) {
         }
     }
 }
+
+/// Build the wasmi `Engine` used for *validation* differential testing.
+///
+/// Matched to SpaceWasm's accepted language: Wasm 1.0 MVP **plus custom page
+/// sizes** (SpaceWasm's one supported post-MVP proposal). Feature parity matters
+/// here -- a feature one validator enables and the other doesn't would make them
+/// disagree for reasons that are not bugs. Fuel is irrelevant to validation.
+#[cfg(feature = "differential")]
+fn build_wasmi_validate_engine() -> wasmi::Engine {
+    let mut config = wasmi::Config::default();
+    config
+        .wasm_mutable_global(true)
+        .floats(true)
+        // SpaceWasm supports custom page sizes; enable it so the two validators
+        // agree on modules that use them.
+        .wasm_custom_page_sizes(true)
+        // Everything else post-MVP: off.
+        .wasm_multi_value(false)
+        .wasm_multi_memory(false)
+        .wasm_sign_extension(false)
+        .wasm_saturating_float_to_int(false)
+        .wasm_bulk_memory(false)
+        .wasm_reference_types(false)
+        .wasm_tail_call(false)
+        .wasm_extended_const(false)
+        .wasm_memory64(false)
+        .wasm_wide_arithmetic(false);
+    wasmi::Engine::new(&config)
+}
+
+#[cfg(feature = "differential")]
+fn with_wasmi_validate_engine<R>(f: impl FnOnce(&wasmi::Engine) -> R) -> R {
+    thread_local! {
+        static ENGINE: wasmi::Engine = build_wasmi_validate_engine();
+    }
+    ENGINE.with(f)
+}
+
+/// Oracle: differentially test the *validator*.
+///
+/// Decodes+validates the same bytes with both engines and checks the accept /
+/// reject decisions. We assert only the **soundness** direction: if SpaceWasm
+/// *accepts* a module that wasmi (a conformant validator with a matched feature
+/// set) *rejects* as invalid, that is a potential soundness bug -- SpaceWasm
+/// admitting a module it should have refused -- and is reported by panicking.
+///
+/// The reverse direction (SpaceWasm rejects what wasmi accepts) is intentionally
+/// **not** flagged: SpaceWasm is an embedded engine with stricter resource
+/// limits (bounded code pages, control-frame and operand-stack depth, allocation
+/// size), so it legitimately rejects large-but-valid modules that wasmi accepts.
+/// Distinguishing those limit rejections from true completeness bugs needs error
+/// classification and is left to a future refinement.
+///
+/// Best driven with the [`crate::generators::MalformedModule`] generator, whose
+/// byte-level mutations of valid modules densely exercise the accept/reject
+/// boundary.
+#[cfg(feature = "differential")]
+pub fn validate_differential(wasm: &[u8]) {
+    crate::init_fuzzing();
+
+    // `load_module` runs SpaceWasm's full decode + validate and returns whether
+    // it accepted the module.
+    let space_ok = load_module(wasm);
+    let wasmi_ok = with_wasmi_validate_engine(|engine| wasmi::Module::new(engine, wasm).is_ok());
+
+    if space_ok && !wasmi_ok {
+        log_wasm(wasm);
+        panic!(
+            "validation soundness divergence: SpaceWasm accepted a module that wasmi rejected as invalid"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "differential"))]
+mod validate_differential_tests {
+    use super::*;
+
+    /// The validation oracle must not fire on modules the two validators agree
+    /// on: a well-formed MVP module (both accept) and garbage (both reject).
+    #[test]
+    fn validate_agrees_on_valid_and_garbage() {
+        let valid = wat::parse_str(r#"(module (func (export "f") (result i32) i32.const 1))"#)
+            .unwrap();
+        // Both accept -> no panic.
+        validate_differential(&valid);
+        assert!(load_module(&valid));
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::new(e, &valid).is_ok()));
+
+        // Random garbage: both reject -> no panic, and neither validator accepts.
+        let garbage = [0x00u8, 0x61, 0x73, 0x6d, 0xff, 0xff, 0xff, 0xff, 0x13, 0x37];
+        validate_differential(&garbage);
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(e, &garbage).is_ok()));
+
+        // A module using a disabled proposal (multi-value result) must be
+        // rejected by both, so the oracle stays quiet.
+        let multi = wat::parse_str(
+            r#"(module (func (export "f") (result i32 i32) i32.const 1 i32.const 2))"#,
+        )
+        .unwrap();
+        validate_differential(&multi);
+        assert!(!load_module(&multi));
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(e, &multi).is_ok()));
+    }
+}

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -518,17 +518,23 @@ mod validate_differential_tests {
     /// on: a well-formed MVP module (both accept) and garbage (both reject).
     #[test]
     fn validate_agrees_on_valid_and_garbage() {
-        let valid = wat::parse_str(r#"(module (func (export "f") (result i32) i32.const 1))"#)
-            .unwrap();
+        let valid =
+            wat::parse_str(r#"(module (func (export "f") (result i32) i32.const 1))"#).unwrap();
         // Both accept -> no panic.
         validate_differential(&valid);
         assert!(load_module(&valid));
-        assert!(with_wasmi_validate_engine(|e| wasmi::Module::new(e, &valid).is_ok()));
+        assert!(with_wasmi_validate_engine(|e| wasmi::Module::new(
+            e, &valid
+        )
+        .is_ok()));
 
         // Random garbage: both reject -> no panic, and neither validator accepts.
         let garbage = [0x00u8, 0x61, 0x73, 0x6d, 0xff, 0xff, 0xff, 0xff, 0x13, 0x37];
         validate_differential(&garbage);
-        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(e, &garbage).is_ok()));
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(
+            e, &garbage
+        )
+        .is_ok()));
 
         // A module using a disabled proposal (multi-value result) must be
         // rejected by both, so the oracle stays quiet.
@@ -538,6 +544,9 @@ mod validate_differential_tests {
         .unwrap();
         validate_differential(&multi);
         assert!(!load_module(&multi));
-        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(e, &multi).is_ok()));
+        assert!(!with_wasmi_validate_engine(|e| wasmi::Module::new(
+            e, &multi
+        )
+        .is_ok()));
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +180,15 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -183,7 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -231,6 +252,12 @@ name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -341,6 +368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +418,7 @@ dependencies = [
  "log",
  "spacewasm",
  "wasm-smith",
+ "wasmi",
  "wasmprinter",
 ]
 
@@ -392,6 +429,22 @@ dependencies = [
  "libfuzzer-sys",
  "spacewasm",
  "spacewasm-fuzzing",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
 ]
 
 [[package]]
@@ -421,6 +474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
 name = "wasm-smith"
 version = "0.220.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,7 +524,48 @@ dependencies = [
  "flagset",
  "indexmap",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.220.1",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+ "wat",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
 ]
 
 [[package]]
@@ -469,6 +579,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags",
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+dependencies = [
+ "bitflags",
+ "indexmap",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.220.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +606,29 @@ checksum = "bd090e11ef5f27428d72702801dc5ca93a9612dfc775b1f9eea6dc3f6265f17e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.220.1",
+]
+
+[[package]]
+name = "wast"
+version = "256.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.256.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,11 +10,18 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 spacewasm = { path = "..", features = ["strict-assertions"] }
-spacewasm-fuzzing = { path = "../crates/fuzzing", features = [] }
+spacewasm-fuzzing = { path = "../crates/fuzzing", features = ["differential"] }
 
 [[bin]]
 name = "validate"
 path = "fuzz_targets/validate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "validate_differential"
+path = "fuzz_targets/validate_differential.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/validate_differential.rs
+++ b/fuzz/fuzz_targets/validate_differential.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use spacewasm_fuzzing::generators::MalformedModule;
+use spacewasm_fuzzing::oracles;
+
+fuzz_target!(|module: MalformedModule| {
+    oracles::validate_differential(module.wasm());
+});


### PR DESCRIPTION
It decodes and validates the same bytes with both SpaceWasm and Wasmi and panics upon validation divergence.

There's more differential fuzzing possible beyond just validation, but more extensive differential fuzzing is over an order of magnitude slower and doesn't find any bugs in `main`. It might be worth adding in the future as more proposals are implemented.