### PR TITLE
Stop StateHistory panicking when the trace buffer has zero capacity

### DIFF
--- a/crates/spacewasm_util/src/trace.rs
+++ b/crates/spacewasm_util/src/trace.rs
@@ -32,6 +32,10 @@ impl StateHistory {
     }
 
     pub fn record(&mut self, snapshot: StateSnapshot) {
+        // Nothing to hold, and the branch below would index an empty Vec.
+        if self.capacity == 0 {
+            return;
+        }
         if self.snapshots.len() < self.capacity {
             self.snapshots.push(snapshot);
         } else {

--- a/crates/spacewasm_util/tests/state_history.rs
+++ b/crates/spacewasm_util/tests/state_history.rs
@@ -1,0 +1,105 @@
+use spacewasm::JumpTarget;
+use spacewasm_util::{RustSystemAllocator, StateHistory, StateSnapshot};
+
+spacewasm::global_allocator!(RustSystemAllocator, RustSystemAllocator);
+
+fn snap(pc: u32, instruction: &'static str) -> StateSnapshot {
+    StateSnapshot {
+        pc: JumpTarget(pc),
+        sp: pc as usize,
+        fp: 0,
+        instruction,
+        metadata: None,
+    }
+}
+
+fn pcs(history: &StateHistory) -> Vec<u32> {
+    history.iter().map(|s| s.pc.0).collect()
+}
+
+#[test]
+fn keeps_insertion_order_below_capacity() {
+    let mut h = StateHistory::new(4);
+    for i in 0..3 {
+        h.record(snap(i, "nop"));
+    }
+    assert_eq!(pcs(&h), vec![0, 1, 2]);
+}
+
+#[test]
+fn keeps_insertion_order_at_capacity() {
+    let mut h = StateHistory::new(3);
+    for i in 0..3 {
+        h.record(snap(i, "nop"));
+    }
+    assert_eq!(pcs(&h), vec![0, 1, 2]);
+}
+
+#[test]
+fn drops_oldest_once_wrapped() {
+    let mut h = StateHistory::new(3);
+    for i in 0..5 {
+        h.record(snap(i, "nop"));
+    }
+    assert_eq!(pcs(&h), vec![2, 3, 4]);
+}
+
+#[test]
+fn stays_correct_across_several_wraps() {
+    let mut h = StateHistory::new(3);
+    for i in 0..10 {
+        h.record(snap(i, "nop"));
+    }
+    assert_eq!(pcs(&h), vec![7, 8, 9]);
+}
+
+#[test]
+fn capacity_one_keeps_only_the_latest() {
+    let mut h = StateHistory::new(1);
+    for i in 0..4 {
+        h.record(snap(i, "nop"));
+    }
+    assert_eq!(pcs(&h), vec![3]);
+}
+
+// `--limit 0` reaches this and used to panic.
+#[test]
+fn zero_capacity_records_nothing() {
+    let mut h = StateHistory::new(0);
+    h.record(snap(1, "nop"));
+    h.record(snap(2, "nop"));
+    assert_eq!(pcs(&h), Vec::<u32>::new());
+    assert!(h.dump().contains("Execution Trace"));
+}
+
+#[test]
+fn empty_history_iterates_empty() {
+    let h = StateHistory::new(4);
+    assert_eq!(pcs(&h), Vec::<u32>::new());
+}
+
+#[test]
+fn dump_lists_instructions_oldest_first() {
+    let mut h = StateHistory::new(2);
+    h.record(snap(0, "i32_const"));
+    h.record(snap(1, "i32_add"));
+    let out = h.dump();
+    let first = out.find("i32_const").expect("i32_const missing from dump");
+    let second = out.find("i32_add").expect("i32_add missing from dump");
+    assert!(first < second, "dump is not oldest-first:\n{out}");
+}
+
+#[test]
+fn dump_renders_metadata() {
+    let mut h = StateHistory::new(2);
+    h.record(StateSnapshot {
+        pc: JumpTarget(7),
+        sp: 1,
+        fp: 2,
+        instruction: "local_get",
+        metadata: Some(("idx", 3)),
+    });
+    let out = h.dump();
+    assert!(out.contains("local_get"), "{out}");
+    assert!(out.contains("idx=3"), "{out}");
+}


### PR DESCRIPTION
`spacewasm-trace --limit 0` crashes:

```
thread 'main' panicked at crates/spacewasm_util/src/trace.rs:38:27:
index out of bounds: the len is 0 but the index is 0
```

`--limit` parses straight into `StateHistory::new`, and `0` is accepted. On the first recorded instruction `record` takes the else branch and indexes an empty `Vec`. Past that line, `(self.index + 1) % self.capacity` would divide by zero.

`record` now returns early when capacity is zero, so the buffer holds nothing and the tool prints an empty trace instead of aborting.

Before, on a module with one exported function:

```
$ spacewasm-trace add.wasm --limit 0
thread 'main' panicked at crates/spacewasm_util/src/trace.rs:38:27
```

After:

```
=== Execution Trace (last 0 instructions) ===
===============================================

Result: Completed successfully
```

Also adds `tests/state_history.rs`. `spacewasm_util` had no tests at all, so these cover the ring buffer rather than only the zero case: ordering below capacity, at capacity, across several wraps, capacity one, empty iteration, and `dump` output including metadata. With the fix reverted, `zero_capacity_records_nothing` fails and the other eight pass.

`cargo fmt --all -- --check` and `cargo clippy -p spacewasm_util --all-targets --all-features -- -D warnings` are both clean.

### Generative AI disclosure

Per `AI_POLICY.md`. This change is confined to `crates/*`; no `src/*` code was touched.

- **Type of assistance:** bug diagnosis, the one-line guard, and the tests
- **Scope:** `crates/spacewasm_util/src/trace.rs`, `crates/spacewasm_util/tests/state_history.rs`
- **Tool:** Claude (Claude Code)
- **Level of modification:** reviewed and edited before submitting. Every test was run locally, and the panic was reproduced through the CLI both before and after the fix.
