### PR TITLE
Guard read_vec_in against oversized declared vector length

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -28,6 +28,14 @@ const CONTINUATION_BIT: u8 = 0b10000000;
 
 const INTEGER_BIT_FLAG: u8 = !CONTINUATION_BIT;
 
+/// Cap on the in-memory size of a single heap vector decoded from module bytes.
+/// `Vec::new_in` reserves `len * size_of::<T>()` up front, so without this a
+/// few-byte module can drive a multi-gigabyte allocation (or overflow the
+/// layout outright on 32-bit targets). A byte budget rather than an element
+/// count so wide element types are bounded the same way. Sized to match the
+/// `MAX_TABLE_ELEMENTS` bound in `types.rs`.
+const MAX_DECODE_BYTES: u64 = 10 * 1024 * 1024;
+
 /// A struct for managing and reading Wasm bytecode
 /// Its purpose is to abstract parsing basic Wasm values from the bytecode
 /// and managing the chunks from a stream as they are read.
@@ -465,6 +473,9 @@ impl<'wasm> Reader<'wasm> {
         VA: Allocator,
     {
         let len = self.read_u32()?;
+        if u64::from(len) * size_of::<T>() as u64 > MAX_DECODE_BYTES {
+            return Err(ValidationError::VecTooLong);
+        }
         let mut out = Vec::new_in(alloc, len)?;
         for _ in 0..len {
             out.push(read_element(self)?);
@@ -650,6 +661,21 @@ mod tests {
         let v = reader.read_vec(|r| r.read_u8()).unwrap();
         assert_eq!(&*v, &[0x0A, 0x0B, 0x0C]);
         assert_eq!(reader.offset(), data.len());
+    }
+
+    #[test]
+    fn read_vec_in_rejects_oversized_byte_budget() {
+        // 1_000_000 entries is far below any plausible element-count cap, but
+        // at 16 bytes each that is a 16 MiB allocation - the byte budget has
+        // to reject it before `Vec::new_in` reserves the space. The length
+        // prefix is enough; the check returns before any element is read.
+        let data = [0xC0u8, 0x84, 0x3D]; // LEB128 1_000_000
+        let mut stream = ChunkStream::new(&data, 3);
+        let mut reader = Reader::new(&mut stream);
+        assert!(matches!(
+            reader.read_vec(|r| r.strip_bytes::<16>()),
+            Err(ValidationError::VecTooLong)
+        ));
     }
 
     #[test]

--- a/tests/regression/decode-errors.wast
+++ b/tests/regression/decode-errors.wast
@@ -179,3 +179,7 @@
 (assert_invalid
   (module binary "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\08\01\06\01\ff\ff\03\7f\0b")
   "call frame too large")
+
+(assert_invalid
+  (module binary "\00asm\01\00\00\00\01\05\ff\ff\ff\ff\0f")
+  "length out of bounds")


### PR DESCRIPTION
Fixes #158.

`read_vec_in` reads a declared `u32` length and passes it straight to the allocator with no bound check, unlike the sibling `read_vec_stack`, which rejects an oversized length first. #158 reported this panicking on 32-bit when the length overflows the allocation layout.

An earlier PR (#177) already stopped the panic by making the underlying allocation error graceful instead of unwrapping - but that just changed the symptom. The result was a generic `AllocError` instead of the spec-compliant `VecTooLong` that `read_vec_stack` already returns for this case, and on 64-bit the same declared length still reached the allocator and tried an actual multi-gigabyte allocation.

`read_vec_in` now rejects a length whose backing allocation (`len * size_of::<T>()`) would exceed a 10 MiB decode budget, up front on any architecture. This is a byte budget rather than a flat element count (per philphauler's analysis on this PR): for `u8` it matches the old ~10M-element intent, but for a wider element type a 10M-element cap would still wave through a 160 MiB allocation, and the byte budget closes that.

Ran the regression case from #158 plus a new `reader` unit test for the wide-element case on both targets:
```
$ cargo test -p spacewasm --target i686-pc-windows-gnu
test result: ok. 264 passed; ...
test result: ok. 75 passed; ...  (core_integration)
test result: ok. 14 passed; ...  (regression_integration)

$ cargo test -p spacewasm
test result: ok. 264 passed; ...
```
Full suites on both targets pass with no regressions; `cargo clippy` and `cargo fmt --check` clean.
