### PR TITLE
test: implement Default for LimitedVec

### DIFF
--- a/tests/util/inspector.rs
+++ b/tests/util/inspector.rs
@@ -23,6 +23,12 @@ impl<T> LimitedVec<T> {
     }
 }
 
+impl<T> Default for LimitedVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> From<LimitedVec<T>> for Vec<T> {
     fn from(value: LimitedVec<T>) -> Self {
         value.0.into_iter().collect()


### PR DESCRIPTION
## Summary

Implements `Default` for `LimitedVec<T>` in `tests/util/inspector.rs` by delegating to `Self::new()`.

This resolves the `clippy::new_without_default` failure when running:

```bash
cargo clippy --test core_integration -- -D warnings
```
## Testing

Verified locally with:

```bash
cargo clippy --test core_integration -- -D warnings
```

## AI disclosure

ChatGPT was used to assist with drafting this pull request description. The submitted test-utility change was reviewed and verified locally.