### PR TITLE
Add a regression case for unbounded vector counts in the decoder

### DIFF
--- a/tests/regression/decode-errors.wast
+++ b/tests/regression/decode-errors.wast
@@ -179,3 +179,14 @@
 (assert_invalid
   (module binary "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\08\01\06\01\ff\ff\03\7f\0b")
   "call frame too large")
+
+;; ---------------------------------------------------------------------------
+;; A vector count is bounded by the bytes remaining in its section before the
+;; decoder sizes an allocation for it. Left unchecked, a count of 0xFFFFFFFF
+;; drove a `Layout::array` panic on 32-bit targets (#158) or a multi-gigabyte
+;; allocation attempt on 64-bit hosts.
+;; type section (id 1): size=5, count=0xFFFFFFFF (LEB \ff\ff\ff\ff\0f), no entries
+;; ---------------------------------------------------------------------------
+(assert_invalid
+  (module binary "\00asm\01\00\00\00\01\05\ff\ff\ff\ff\0f")
+  "length out of bounds")


### PR DESCRIPTION
Regression case for #158, fixed on `main` by #189: `read_vec_in` now rejects a vector count larger than the bytes left in its section before allocating (`src/reader.rs:501-502`), and `Vec::new_in` maps the layout error instead of unwrapping it (`src/util/vec.rs:163-164`).

The case is a type section declaring 0xFFFFFFFF entries, next to the existing table-limit case of the same shape.

| | 565b9f7 (before) | 2eceda3 (main) |
| --- | --- | --- |
| `i686-unknown-linux-musl` | panic, `vec.rs:137: LayoutError` | rejected, `length out of bounds` |
| x86-64 | `AllocError(AllocationFailed)`, unmatched | rejected, `length out of bounds` |

Full `regression_integration` passes on both targets with the case, and the Miri wast conversion picks it up unchanged.

Closes #158.

*AI use per `AI_POLICY.md`: Claude Code assisted with the verification runs and this description. The change is a `.wast` case under `tests/`; no `src/` change.*
