### PR TITLE
Convert Vec<T> to Box<[T]>

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -70,9 +70,7 @@ impl WasmStream for ByteStream {
 
         if let Some(ref mut vec) = self.buffer {
             self.consumed = true;
-            let inner = unsafe {
-                InnerVec::from_raw_parts(vec.as_mut_ptr(), vec.len() as u32, vec.len() as u32)
-            };
+            let inner = unsafe { InnerVec::from_raw_parts(vec.as_mut_ptr(), vec.len(), vec.len()) };
             Ok(Some(inner))
         } else {
             Ok(None)
@@ -170,7 +168,7 @@ mod fuzz_alloc {
     spacewasm::global_allocator!(SystemAllocator, SystemAllocator);
 }
 
-const MAX_CODE_PAGES: u32 = 128;
+const MAX_CODE_PAGES: usize = 128;
 const MAX_CONTROL_FRAMES: usize = 128;
 const MAX_STACK_DEPTH: usize = 256;
 

--- a/crates/spacewasi/src/main.rs
+++ b/crates/spacewasi/src/main.rs
@@ -170,7 +170,7 @@ fn main() -> ExitCode {
     let mut code_builder = CodeBuilder::new(CompilerOptions {
         allow_memory_grow: true,
         max_backpatch_iterations: None,
-        max_code_pages: MAX_PAGES as u32,
+        max_code_pages: MAX_PAGES,
     })
     .unwrap();
     let mut engine = Engine::new(STACK_SIZE, 1, spacewasm::vec![preview1_module]).unwrap();

--- a/crates/spacewasm_c_api/cbindgen.toml
+++ b/crates/spacewasm_c_api/cbindgen.toml
@@ -13,14 +13,10 @@ header = """/*
  */"""
 after_includes = """
 
-#if defined(__has_c_attribute)
-#  if __has_c_attribute(noreturn)
-#    define SPACEWASM_NORETURN [[noreturn]] /* Standard C23 attribute */
-#  endif
-#endif
-
 #if !defined(SPACEWASM_NORETURN)
-#  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#  if defined(__has_c_attribute) && __has_c_attribute(noreturn)
+#    define SPACEWASM_NORETURN [[noreturn]] /* Standard C23 attribute */
+#  elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #    define SPACEWASM_NORETURN _Noreturn /* Standard C11 keyword */
 #  elif defined(__GNUC__) || defined(__clang__)
 #    define SPACEWASM_NORETURN __attribute__((noreturn)) /* GCC / Clang extension */

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -10,14 +10,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#if defined(__has_c_attribute)
-#  if __has_c_attribute(noreturn)
-#    define SPACEWASM_NORETURN [[noreturn]] /* Standard C23 attribute */
-#  endif
-#endif
-
 #if !defined(SPACEWASM_NORETURN)
-#  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#  if defined(__has_c_attribute) && __has_c_attribute(noreturn)
+#    define SPACEWASM_NORETURN [[noreturn]] /* Standard C23 attribute */
+#  elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #    define SPACEWASM_NORETURN _Noreturn /* Standard C11 keyword */
 #  elif defined(__GNUC__) || defined(__clang__)
 #    define SPACEWASM_NORETURN __attribute__((noreturn)) /* GCC / Clang extension */

--- a/crates/spacewasm_c_api/include/spacewasm.h
+++ b/crates/spacewasm_c_api/include/spacewasm.h
@@ -386,8 +386,8 @@ typedef void (*spacewasm_dealloc_fn_t)(void *userdata, uint8_t *ptr, size_t size
 
 typedef struct spacewasm_host_t {
     struct spacewasm_host_module_t *ptr;
-    uint32_t capacity;
-    uint32_t len;
+    size_t capacity;
+    size_t len;
 } spacewasm_host_t;
 
 /*
@@ -448,7 +448,7 @@ typedef struct spacewasm_compiler_options_t {
      Maximum number of compiled code pages allowed across all modules loaded
      onto the store.
      */
-    uint32_t max_code_pages;
+    size_t max_code_pages;
 } spacewasm_compiler_options_t;
 
 /*
@@ -498,7 +498,7 @@ void spacewasm_allocator_destroy(struct spacewasm_allocator_t *allocator);
  # Safety
  `dest` must be null or a valid, live pointer to write the new host vector into.
  */
-spacewasm_status_t spacewasm_host_new(uint32_t len, struct spacewasm_host_t *dest);
+spacewasm_status_t spacewasm_host_new(size_t len, struct spacewasm_host_t *dest);
 
 /*
  Add a host module named `name` sized for `max_functions` functions and
@@ -509,8 +509,8 @@ spacewasm_status_t spacewasm_host_new(uint32_t len, struct spacewasm_host_t *des
  */
 spacewasm_status_t spacewasm_add_host_module(struct spacewasm_host_t *host,
                                              const char *name,
-                                             uint32_t max_functions,
-                                             uint32_t max_globals,
+                                             size_t max_functions,
+                                             size_t max_globals,
                                              uint32_t *out_idx);
 
 /*
@@ -568,7 +568,7 @@ spacewasm_status_t spacewasm_load_module(struct spacewasm_t *engine,
  */
 spacewasm_status_t spacewasm_new(struct spacewasm_host_t *host,
                                  size_t stack_size,
-                                 uint32_t max_modules,
+                                 size_t max_modules,
                                  struct spacewasm_compiler_options_t options,
                                  struct spacewasm_t **out_engine);
 

--- a/crates/spacewasm_c_api/src/capi.rs
+++ b/crates/spacewasm_c_api/src/capi.rs
@@ -44,7 +44,7 @@ pub struct spacewasm_compiler_options_t {
 
     /// Maximum number of compiled code pages allowed across all modules loaded
     /// onto the store.
-    pub max_code_pages: u32,
+    pub max_code_pages: usize,
 }
 
 impl From<spacewasm_compiler_options_t> for CompilerOptions {
@@ -107,8 +107,8 @@ pub unsafe extern "C" fn spacewasm_allocator_destroy(allocator: *mut CAllocator)
 #[repr(C)]
 pub struct spacewasm_host_t {
     ptr: *mut HostModule,
-    capacity: u32,
-    len: u32,
+    capacity: usize,
+    len: usize,
 }
 
 impl From<Vec<HostModule>> for spacewasm_host_t {
@@ -146,7 +146,7 @@ const _: () = {
 /// `dest` must be null or a valid, live pointer to write the new host vector into.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn spacewasm_host_new(
-    len: u32,
+    len: usize,
     dest: *mut spacewasm_host_t,
 ) -> spacewasm_status_t {
     if dest.is_null() {
@@ -167,8 +167,8 @@ pub unsafe extern "C" fn spacewasm_host_new(
 pub unsafe extern "C" fn spacewasm_add_host_module(
     host: *mut spacewasm_host_t,
     name: *const c_char,
-    max_functions: u32,
-    max_globals: u32,
+    max_functions: usize,
+    max_globals: usize,
     out_idx: *mut u32,
 ) -> spacewasm_status_t {
     let functions = check!(Vec::new(max_functions).map_err(status::alloc_status));
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn spacewasm_load_module(
 pub unsafe extern "C" fn spacewasm_new(
     host: *mut spacewasm_host_t,
     stack_size: usize,
-    max_modules: u32,
+    max_modules: usize,
     options: spacewasm_compiler_options_t,
     out_engine: *mut *mut CEngine,
 ) -> spacewasm_status_t {
@@ -353,9 +353,8 @@ pub unsafe extern "C" fn spacewasm_new(
         unsafe { host.read() }.into()
     };
 
-    let engine = check!(
-        Engine::new(stack_size, max_modules as usize, host_modules).map_err(status::memory_status)
-    );
+    let engine =
+        check!(Engine::new(stack_size, max_modules, host_modules).map_err(status::memory_status));
 
     let code_builder = check!(CodeBuilder::new(options.into()).map_err(status::alloc_status));
 

--- a/crates/spacewasm_c_api/src/stream.rs
+++ b/crates/spacewasm_c_api/src/stream.rs
@@ -86,7 +86,7 @@ impl WasmStream for CallbackStream {
                 // `capacity: 0` ensures the `Chunk` drop assertion holds and no
                 // deallocation of borrowed memory is attempted.
                 Ok(Some(unsafe {
-                    InnerVec::from_raw_parts(out_buf as *mut u8, 0, out_len as u32)
+                    InnerVec::from_raw_parts(out_buf as *mut u8, 0, out_len)
                 }))
             }
         }

--- a/crates/spacewasm_c_api/src/tests.rs
+++ b/crates/spacewasm_c_api/src/tests.rs
@@ -340,7 +340,7 @@ static GLOBAL_IMPORTER_WASM: &[u8] = &[
 // ---- shared driving helpers -------------------------------------------------
 
 /// Default compiler options bounding a test store to `max_code_pages` pages.
-fn opts(max_code_pages: u32) -> spacewasm_compiler_options_t {
+fn opts(max_code_pages: usize) -> spacewasm_compiler_options_t {
     spacewasm_compiler_options_t {
         allow_memory_grow: false,
         max_backpatch_iterations: 0,
@@ -349,7 +349,7 @@ fn opts(max_code_pages: u32) -> spacewasm_compiler_options_t {
 }
 
 /// Create an empty (no host modules) store with the given capacities.
-fn new_store(stack_size: usize, max_modules: u32, max_code_pages: u32) -> *mut CEngine {
+fn new_store(stack_size: usize, max_modules: usize, max_code_pages: usize) -> *mut CEngine {
     let mut host = core::mem::MaybeUninit::<spacewasm_host_t>::uninit();
     let st = unsafe { spacewasm_host_new(0, host.as_mut_ptr()) };
     assert_eq!(st, status::SPACEWASM_OK, "host_new");

--- a/crates/spacewasm_std/benches/coremark.rs
+++ b/crates/spacewasm_std/benches/coremark.rs
@@ -11,7 +11,7 @@ spacewasm::global_allocator!(
     PageAllocator::new(RustSystemAllocator, 8192)
 );
 
-const MAX_CODE_PAGES: u32 = 32;
+const MAX_CODE_PAGES: usize = 32;
 const MAX_CONTROL_FRAMES: usize = 64;
 const MAX_STACK_DEPTH: usize = 256;
 

--- a/crates/spacewasm_std/src/main.rs
+++ b/crates/spacewasm_std/src/main.rs
@@ -12,7 +12,7 @@ spacewasm::global_allocator!(
     PageAllocator::new(RustSystemAllocator, 8192)
 );
 
-const MAX_CODE_PAGES: u32 = 256;
+const MAX_CODE_PAGES: usize = 256;
 const MAX_CONTROL_FRAMES: usize = 64;
 const MAX_STACK_DEPTH: usize = 256;
 

--- a/crates/spacewasm_util/src/bin/spacewasm-trace.rs
+++ b/crates/spacewasm_util/src/bin/spacewasm-trace.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::process;
 
-const MAX_CODE_PAGES: u32 = 128;
+const MAX_CODE_PAGES: usize = 128;
 const MAX_CONTROL_FRAMES: usize = 128;
 const MAX_STACK_DEPTH: usize = 256;
 
@@ -48,8 +48,8 @@ impl WasmStream for ByteStream {
         let inner = unsafe {
             InnerVec::from_raw_parts(
                 self.buffer.as_mut_ptr(),
-                self.buffer.len() as u32,
-                self.buffer.len() as u32,
+                self.buffer.len(),
+                self.buffer.len(),
             )
         };
         Ok(Some(inner))

--- a/crates/spacewasm_util/src/file.rs
+++ b/crates/spacewasm_util/src/file.rs
@@ -73,9 +73,7 @@ impl WasmStream for FileStream {
         if n == 0 {
             Ok(None)
         } else {
-            let m = unsafe {
-                InnerVec::from_raw_parts(buf.as_mut_ptr(), buf.capacity() as u32, n as u32)
-            };
+            let m = unsafe { InnerVec::from_raw_parts(buf.as_mut_ptr(), buf.capacity(), n) };
 
             self.n += n;
             self.used.insert(buf.as_mut_ptr(), buf);

--- a/src/code.rs
+++ b/src/code.rs
@@ -93,17 +93,20 @@ impl Module {
         let size = wasm.read_u32()?;
         let start = wasm.offset();
 
-        let empty_f = Func {
-            ty: TypeIdx(0),
-            stack_usage: 0,
-            local_size: 0,
-            parameter_size: 0,
-            return_ty: None,
-            locals: Vec::zero().into(),
-            expr: Expr::zero(),
+        let placeholder = {
+            let f = &self.functions[i];
+            Func {
+                ty: f.ty,
+                stack_usage: f.stack_usage,
+                local_size: f.local_size,
+                parameter_size: f.parameter_size,
+                return_ty: f.return_ty,
+                locals: Vec::zero().into(),
+                expr: Expr::zero(),
+            }
         };
 
-        let mut f = core::mem::replace(&mut self.functions[i], empty_f);
+        let mut f = core::mem::replace(&mut self.functions[i], placeholder);
 
         wasm.with_limit(size as usize, |wasm| {
             f.locals = wasm

--- a/src/code.rs
+++ b/src/code.rs
@@ -76,7 +76,7 @@ pub struct Func {
 
     /// Local variables allocated in this functions frame
     /// Read in the code section
-    pub locals: Vec<(u16, ValType)>,
+    pub locals: Box<[(u16, ValType)]>,
 
     /// Functions entry point
     pub expr: Expr,
@@ -93,20 +93,31 @@ impl Module {
         let size = wasm.read_u32()?;
         let start = wasm.offset();
 
-        let empty_f = self.functions[i].clone();
+        let empty_f = Func {
+            ty: TypeIdx(0),
+            stack_usage: 0,
+            local_size: 0,
+            parameter_size: 0,
+            return_ty: None,
+            locals: Vec::zero().into(),
+            expr: Expr::zero(),
+        };
+
         let mut f = core::mem::replace(&mut self.functions[i], empty_f);
 
         wasm.with_limit(size as usize, |wasm| {
-            f.locals = wasm.read_vec(|w| {
-                let n = w.read_u32()?;
-                let t = ValType::read(w)?;
+            f.locals = wasm
+                .read_vec(|w| {
+                    let n = w.read_u32()?;
+                    let t = ValType::read(w)?;
 
-                if n > 0xFFFF {
-                    return Err(ValidationError::TooManyLocals);
-                }
+                    if n > 0xFFFF {
+                        return Err(ValidationError::TooManyLocals);
+                    }
 
-                Ok((n as u16, t))
-            })?;
+                    Ok((n as u16, t))
+                })?
+                .into();
 
             // Compute the local size in words
             let mut total_size: usize = 0;

--- a/src/interpreter_tests.rs
+++ b/src/interpreter_tests.rs
@@ -50,8 +50,8 @@ mod tests {
         // Create a minimal valid module
         let module = Module {
             name: "test".try_into().unwrap(),
-            types: crate::Vec::zero(),
-            functions: crate::Vec::zero(),
+            types: crate::Vec::zero().into(),
+            functions: crate::Vec::zero().into(),
             table: None,
             memory: Some(MemoryKind::Owned(
                 crate::Rc::new(
@@ -69,10 +69,10 @@ mod tests {
                 )
                 .unwrap(),
             )),
-            globals: crate::Vec::zero(),
+            globals: crate::Vec::zero().into(),
             start: None,
-            imports: crate::Vec::zero(),
-            exports: crate::Vec::zero(),
+            imports: crate::Vec::zero().into(),
+            exports: crate::Vec::zero().into(),
         };
 
         let module_ref = engine.push_module(module).unwrap();

--- a/src/module.rs
+++ b/src/module.rs
@@ -27,13 +27,13 @@ pub enum TableElement {
 #[derive(Debug)]
 pub struct Module {
     pub name: String,
-    pub types: Vec<FuncType>,
-    pub functions: Vec<Func>,
+    pub types: Box<[FuncType]>,
+    pub functions: Box<[Func]>,
     pub table: Option<TableKind>,
     pub memory: Option<MemoryKind>,
-    pub globals: Vec<Global>,
-    pub imports: Vec<Import>,
-    pub exports: Vec<Export>,
+    pub globals: Box<[Global]>,
+    pub imports: Box<[Import]>,
+    pub exports: Box<[Export]>,
     pub start: Option<Ref>,
 }
 
@@ -120,13 +120,13 @@ impl Module {
 
         let mut module = Module {
             name: name.try_into()?,
-            types: Vec::zero(),
-            functions: Vec::zero(),
+            types: Vec::zero().into(),
+            functions: Vec::zero().into(),
             table: None,
             memory: None,
-            globals: Vec::zero(),
-            imports: Vec::zero(),
-            exports: Vec::zero(),
+            globals: Vec::zero().into(),
+            imports: Vec::zero().into(),
+            exports: Vec::zero().into(),
             start: None,
         };
 
@@ -208,10 +208,10 @@ impl Module {
                 CustomSection::read(wasm, section_size, custom_handler)?;
             }
             Type => {
-                self.types = TypeSection::read(wasm)?;
+                self.types = TypeSection::read(wasm)?.into();
             }
             Import => {
-                self.imports = ImportSection::read(wasm, store, self)?;
+                self.imports = ImportSection::read(wasm, store, self)?.into();
 
                 // We need to resolve some imports into the module (i.e. memory and table)
                 for import in &self.imports {
@@ -278,7 +278,7 @@ impl Module {
                 }
             }
             Function => {
-                self.functions = FunctionSection::read(wasm, self)?;
+                self.functions = FunctionSection::read(wasm, self)?.into();
             }
             Table => {
                 if self.table.is_some() {
@@ -291,10 +291,10 @@ impl Module {
                 self.memory = MemorySection::read(wasm, self, allocator)?;
             }
             Global => {
-                self.globals = GlobalSection::read(wasm, store, self)?;
+                self.globals = GlobalSection::read(wasm, store, self)?.into();
             }
             Export => {
-                self.exports = ExportSection::read(wasm, self)?;
+                self.exports = ExportSection::read(wasm, self)?.into();
             }
             Start => {
                 let idx = FuncIdx::read(wasm)?;
@@ -600,7 +600,7 @@ impl Func {
             local_size: 0,
             parameter_size: parameter_size as u8,
             return_ty,
-            locals: Vec::zero(),
+            locals: Vec::zero().into(),
             expr: Expr::zero(),
         })
     }
@@ -786,7 +786,7 @@ pub struct ExportSection;
 impl ExportSection {
     pub fn read(wasm: &mut Reader, module: &Module) -> Result<Vec<Export>, ValidationError> {
         let len = wasm.read_u32()?;
-        let mut out: Vec<Export> = Vec::new(len)?;
+        let mut out: Vec<Export> = Vec::new(len as usize)?;
         for _ in 0..len {
             let e = Export::read(wasm, module)?;
             // Check for duplicate export name

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -502,7 +502,7 @@ impl<'wasm> Reader<'wasm> {
             return Err(ValidationError::VecTooLong);
         }
 
-        let mut out = Vec::new_in(alloc, len)?;
+        let mut out = Vec::new_in(alloc, len as usize)?;
         for _ in 0..len {
             out.push(read_element(self)?);
         }
@@ -566,8 +566,8 @@ mod tests {
             self.pos += n;
             Ok(Some(InnerVec {
                 ptr,
-                capacity: n as u32,
-                len: n as u32,
+                capacity: n,
+                len: n,
             }))
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -25,7 +25,7 @@ impl Store {
         }
 
         Ok(Store {
-            modules: Vec::new(max_modules as u32)?,
+            modules: Vec::new(max_modules)?,
             host_modules,
             zero_memory: Rc::new(Memory::zero())?,
             zero_table: Rc::new_slice_with_default(0)?,

--- a/src/text.rs
+++ b/src/text.rs
@@ -356,7 +356,7 @@ impl CodeBuilder {
         };
 
         // We support up to 24-bit page addresses
-        assert!(page_index < MAX_ADDRESSABLE_CODE_PAGES as usize);
+        assert!(page_index < MAX_ADDRESSABLE_CODE_PAGES);
         assert!(offset < 256);
 
         JumpTarget(((page_index as u32) << 8) | (offset as u32))

--- a/src/text.rs
+++ b/src/text.rs
@@ -232,7 +232,7 @@ pub struct GlobalVariable {
 
 /// The IR encodes code addresses as 24-bit page indices (see [`JumpTarget`]),
 /// so no more than `2^24` code pages can ever be addressed.
-const MAX_ADDRESSABLE_CODE_PAGES: u32 = 1 << 24;
+const MAX_ADDRESSABLE_CODE_PAGES: usize = 1 << 24;
 
 #[derive(Debug, Copy, Clone)]
 pub struct CompilerOptions {
@@ -260,7 +260,7 @@ pub struct CompilerOptions {
     /// loaded onto the store). Oversizing it costs only the pointer table, not the page bodies.
     /// It must be strictly less than `MAX_ADDRESSABLE_CODE_PAGES` (`2^24`) and must be sized to
     /// fit inside a single heap memory page.
-    pub max_code_pages: u32,
+    pub max_code_pages: usize,
 }
 
 /// Low-level builder for paged IR code.

--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -137,7 +137,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     }
 }
 
-impl<T: ?Sized + Clone, A: Allocator + Clone> Box<[T], A> {
+impl<T: Clone, A: Allocator + Clone> Box<[T], A> {
     pub fn try_clone(&self) -> Result<Self, AllocError> {
         let mut n: Vec<T, A> = Vec::new_in(self.alloc.clone(), self.len())?;
 
@@ -152,7 +152,7 @@ impl<T: ?Sized + Clone, A: Allocator + Clone> Box<[T], A> {
     }
 }
 
-impl<T: ?Sized + Clone, A: Allocator + Clone> Clone for Box<[T], A> {
+impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         self.try_clone().expect("Box<T> clone failed")
     }

--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -15,7 +15,7 @@ pub struct Box<T: ?Sized, A: Allocator = GlobalAllocator> {
     alloc: A,
 }
 
-impl<A: Allocator, T: core::fmt::Debug> core::fmt::Debug for Box<T, A> {
+impl<A: Allocator, T: ?Sized + core::fmt::Debug> core::fmt::Debug for Box<T, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         (**self).fmt(f)
     }
@@ -137,6 +137,27 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     }
 }
 
+impl<T: ?Sized + Clone, A: Allocator + Clone> Box<[T], A> {
+    pub fn try_clone(&self) -> Result<Self, AllocError> {
+        let mut n: Vec<T, A> = Vec::new_in(self.alloc.clone(), self.len())?;
+
+        for i in 0..self.len() {
+            // `self.len() <= capacity == n.capacity`, so `push` never overflows.
+            // `self[i].clone()` is evaluated before `push` takes ownership, so a
+            // panic there leaves `n` holding only the already-cloned prefix.
+            n.push(self[i].clone());
+        }
+
+        Ok(n.into())
+    }
+}
+
+impl<T: ?Sized + Clone, A: Allocator + Clone> Clone for Box<[T], A> {
+    fn clone(&self) -> Self {
+        self.try_clone().expect("Box<T> clone failed")
+    }
+}
+
 impl<T: ?Sized, A: Allocator> Deref for Box<T, A> {
     type Target = T;
     fn deref(&self) -> &T {
@@ -193,6 +214,22 @@ impl<T: Ord, A: Allocator> Ord for Box<T, A> {
 impl<T, A: Allocator> From<Vec<T, A>> for Box<[T], A> {
     fn from(v: Vec<T, A>) -> Self {
         v.into_boxed_slice()
+    }
+}
+
+impl<'a, T, A: Allocator> IntoIterator for &'a Box<[T], A> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        (**self).iter()
+    }
+}
+
+impl<'a, T, A: Allocator> IntoIterator for &'a mut Box<[T], A> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        (**self).iter_mut()
     }
 }
 
@@ -278,6 +315,36 @@ mod tests {
         assert_eq!(b.len(), 3);
         assert_eq!(&*b, &[1, 2, 3]);
         drop(b);
+    }
+
+    fn boxed_slice(values: &[u32]) -> Box<[u32]> {
+        let mut v = Vec::new(values.len()).unwrap();
+        for &value in values {
+            v.push(value);
+        }
+        v.into_boxed_slice()
+    }
+
+    #[test]
+    fn test_iter_by_ref() {
+        let mut b = boxed_slice(&[1, 2, 3]);
+
+        let mut sum = 0;
+        for value in &b {
+            sum += *value;
+        }
+        assert_eq!(sum, 6);
+
+        for value in &mut b {
+            *value *= 2;
+        }
+        assert_eq!(&*b, &[2, 4, 6]);
+    }
+
+    #[test]
+    fn test_iter_by_ref_empty() {
+        let b = boxed_slice(&[]);
+        assert_eq!((&b).into_iter().next(), None);
     }
 }
 

--- a/src/util/inner_vec.rs
+++ b/src/util/inner_vec.rs
@@ -73,7 +73,7 @@ impl<T: Sized> InnerVec<T> {
     pub fn try_push(&mut self, value: T) -> Result<(), AllocError> {
         if self.len < self.capacity {
             unsafe {
-                core::ptr::write(self.ptr.add(self.len as usize), value);
+                core::ptr::write(self.ptr.add(self.len), value);
             }
 
             self.len += 1;
@@ -95,7 +95,7 @@ impl<T: Sized> InnerVec<T> {
             None
         } else {
             self.len -= 1;
-            unsafe { Some(core::ptr::read(self.ptr.add(self.len as usize))) }
+            unsafe { Some(core::ptr::read(self.ptr.add(self.len))) }
         }
     }
 
@@ -110,7 +110,7 @@ impl<T> Deref for InnerVec<T> {
         if self.ptr.is_null() {
             &[]
         } else {
-            unsafe { core::slice::from_raw_parts(self.ptr, self.len as usize) }
+            unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
         }
     }
 }
@@ -120,7 +120,7 @@ impl<T> DerefMut for InnerVec<T> {
         if self.ptr.is_null() {
             &mut []
         } else {
-            unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len as usize) }
+            unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len) }
         }
     }
 }
@@ -160,12 +160,15 @@ mod kani_proofs {
     use core::alloc::Layout;
 
     // Helper to create a valid InnerVec with allocated memory
-    unsafe fn create_valid_inner_vec<T>(capacity: u32, alloc: &RustSystemAllocator) -> InnerVec<T> {
+    unsafe fn create_valid_inner_vec<T>(
+        capacity: usize,
+        alloc: &RustSystemAllocator,
+    ) -> InnerVec<T> {
         if capacity == 0 {
             return InnerVec::zero();
         }
 
-        let layout = Layout::array::<T>(capacity as usize).unwrap();
+        let layout = Layout::array::<T>(capacity).unwrap();
         let ptr = unsafe { alloc.alloc(layout).unwrap() as *mut T };
 
         // SAFETY: `ptr` is a fresh allocation valid for `capacity` elements and
@@ -176,7 +179,7 @@ mod kani_proofs {
     // Helper to deallocate an InnerVec
     unsafe fn dealloc_inner_vec<T>(vec: InnerVec<T>, alloc: &RustSystemAllocator) {
         if vec.capacity > 0 && !vec.ptr.is_null() {
-            let layout = Layout::array::<T>(vec.capacity as usize).unwrap();
+            let layout = Layout::array::<T>(vec.capacity).unwrap();
             unsafe { alloc.dealloc(vec.ptr as *mut u8, layout) };
         }
     }
@@ -200,13 +203,13 @@ mod kani_proofs {
     fn verify_len_invariants() {
         unsafe {
             let alloc = RustSystemAllocator;
-            let capacity: u32 = kani::any();
+            let capacity: usize = kani::any();
             kani::assume(capacity > 0 && capacity <= 10);
 
             let mut vec = create_valid_inner_vec::<u32>(capacity, &alloc);
 
             // Start with arbitrary valid state
-            let initial_len: u32 = kani::any();
+            let initial_len: usize = kani::any();
             kani::assume(initial_len <= capacity);
             vec.len = initial_len;
 
@@ -219,10 +222,6 @@ mod kani_proofs {
 
                     // Verify no overflow on increment
                     assert!(vec.len == old_len + 1, "len must increment by 1");
-
-                    // Verify len as usize doesn't truncate
-                    let len_usize = vec.len as usize;
-                    assert!(len_usize == vec.len as usize);
                 }
                 1 if vec.len > 0 => {
                     let old_len = vec.len;
@@ -238,8 +237,7 @@ mod kani_proofs {
             assert!(vec.len <= vec.capacity, "len must never exceed capacity");
 
             //  Offset calculation should not overflow
-            let offset = vec.len as usize;
-            assert!(offset <= capacity as usize, "offset must fit in usize");
+            assert!(vec.len <= capacity, "offset must not exceed capacity");
 
             dealloc_inner_vec(vec, &alloc);
         }
@@ -250,20 +248,20 @@ mod kani_proofs {
     fn verify_pointer_arithmetic_in_bounds() {
         unsafe {
             let alloc = RustSystemAllocator;
-            let capacity: u32 = kani::any();
+            let capacity: usize = kani::any();
             kani::assume(capacity > 0 && capacity <= 10);
 
             let vec = create_valid_inner_vec::<u32>(capacity, &alloc);
 
             // Verify we can compute offsets for all valid indices
-            let index: u32 = kani::any();
+            let index: usize = kani::any();
             kani::assume(index < capacity);
 
             // This pointer arithmetic must be valid
-            let _offset_ptr = vec.ptr.add(index as usize);
+            let _offset_ptr = vec.ptr.add(index);
 
             // The pointer at capacity (one-past-end) should also be valid for iteration
-            let _end_ptr = vec.ptr.add(capacity as usize);
+            let _end_ptr = vec.ptr.add(capacity);
 
             dealloc_inner_vec(vec, &alloc);
         }
@@ -301,13 +299,13 @@ mod kani_proofs {
     #[kani::unwind(4)] // Limit loop unrolling
     fn verify_push_pop_operations() {
         let alloc = RustSystemAllocator;
-        let capacity: u32 = kani::any();
+        let capacity: usize = kani::any();
         kani::assume(capacity > 0 && capacity <= 3);
 
         let mut vec = unsafe { create_valid_inner_vec::<u32>(capacity, &alloc) };
 
         // Test push at different positions
-        let initial_len: u32 = kani::any();
+        let initial_len: usize = kani::any();
         kani::assume(initial_len < capacity);
         vec.len = initial_len;
 
@@ -320,7 +318,7 @@ mod kani_proofs {
         assert_eq!(vec.len, initial_len + 1, "push must increment len");
 
         //  Value is at the old len position (correct offset)
-        let written_value = unsafe { core::ptr::read(vec.ptr.add(push_position as usize)) };
+        let written_value = unsafe { core::ptr::read(vec.ptr.add(push_position)) };
         assert_eq!(written_value, value, "push must write at correct index");
 
         // Now test pop on the same vector
@@ -345,23 +343,23 @@ mod kani_proofs {
     #[kani::unwind(4)] // Limit loop unrolling
     fn verify_deref_only_initialized_region() {
         let alloc = RustSystemAllocator;
-        let capacity: u32 = kani::any();
+        let capacity: usize = kani::any();
         kani::assume(capacity > 0 && capacity <= 3); // Reduced bound
 
         let mut vec = unsafe { create_valid_inner_vec::<u32>(capacity, &alloc) };
 
-        let len: u32 = kani::any();
+        let len: usize = kani::any();
         kani::assume(len <= capacity);
 
         // Initialize elements [0, len)
         for i in 0..len {
             vec.len = i;
-            vec.push(i);
+            vec.push(i as u32);
         }
 
         // Deref creates slice of exactly len elements
         let slice: &[u32] = &*vec;
-        assert_eq!(slice.len(), len as usize);
+        assert_eq!(slice.len(), len);
 
         // Verify first element is accessible if len > 0
         if len > 0 {

--- a/src/util/inner_vec.rs
+++ b/src/util/inner_vec.rs
@@ -14,8 +14,8 @@ use crate::AllocError;
 ///   responsible for both.
 pub struct InnerVec<T: Sized> {
     pub(crate) ptr: *mut T,
-    pub(crate) capacity: u32,
-    pub(crate) len: u32,
+    pub(crate) capacity: usize,
+    pub(crate) len: usize,
 }
 
 impl<T: core::fmt::Debug> core::fmt::Debug for InnerVec<T> {
@@ -49,7 +49,7 @@ impl<T: Sized> InnerVec<T> {
     /// - `InnerVec` neither frees the allocation nor drops its elements, so the
     ///   caller (typically [`crate::Vec`]) retains ownership and must keep the
     ///   allocation valid for as long as the returned value is used.
-    pub unsafe fn from_raw_parts(ptr: *mut T, capacity: u32, len: u32) -> InnerVec<T> {
+    pub unsafe fn from_raw_parts(ptr: *mut T, capacity: usize, len: usize) -> InnerVec<T> {
         InnerVec { ptr, capacity, len }
     }
 
@@ -59,7 +59,7 @@ impl<T: Sized> InnerVec<T> {
     }
 
     pub fn len(&self) -> usize {
-        self.len as usize
+        self.len
     }
 
     pub fn is_empty(&self) -> bool {
@@ -67,7 +67,7 @@ impl<T: Sized> InnerVec<T> {
     }
 
     pub fn capacity(&self) -> usize {
-        self.capacity as usize
+        self.capacity
     }
 
     pub fn try_push(&mut self, value: T) -> Result<(), AllocError> {

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -2,14 +2,13 @@
 // (https://github.com/rust-lang/rust), licensed under Apache-2.0. These
 // portions have been modified for SpaceWasm.
 
-use crate::util::Vec;
-use crate::{Allocator, GlobalAllocator, ValidationError};
+use crate::{Allocator, Box, GlobalAllocator, ValidationError, Vec};
 use core::fmt;
 use core::fmt::Formatter;
 use core::ops::Deref;
 
 #[derive(Clone)]
-pub struct String<A: Allocator = GlobalAllocator>(Vec<u8, A>);
+pub struct String<A: Allocator = GlobalAllocator>(Box<[u8], A>);
 
 impl TryFrom<&[u8]> for String<GlobalAllocator> {
     type Error = ValidationError;
@@ -38,11 +37,11 @@ impl TryFrom<&str> for String<GlobalAllocator> {
     type Error = ValidationError;
 
     fn try_from(value: &str) -> Result<Self, ValidationError> {
-        let mut v = Vec::new(value.len() as u32)?;
+        let mut v = Vec::new(value.len())?;
         for byte in value.as_bytes() {
             v.push(*byte);
         }
-        Ok(String(v))
+        Ok(String(v.into()))
     }
 }
 
@@ -80,7 +79,7 @@ impl<A: Allocator> TryFrom<Vec<u8, A>> for String<A> {
     fn try_from(value: Vec<u8, A>) -> Result<Self, Self::Error> {
         // Validate the integrity of the string
         match core::str::from_utf8(&value) {
-            Ok(_) => Ok(String(value)),
+            Ok(_) => Ok(String(value.into())),
             Err(_) => Err(ValidationError::MalformedUtf8),
         }
     }
@@ -160,14 +159,6 @@ mod tests {
         let s = String::try_from("as ref").unwrap();
         let r: &str = s.as_ref();
         assert_eq!(r, "as ref");
-    }
-
-    #[test]
-    fn test_clone() {
-        let s = String::try_from("clone me").unwrap();
-        let c = s.clone();
-        assert_eq!(&*c, "clone me");
-        assert_eq!(&*s, &*c);
     }
 
     #[test]

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -24,8 +24,7 @@ impl<T> Vec<T, GlobalAllocator> {
     /// length does not fit in a `u32` (instead of silently truncating the cast)
     /// or if allocating the backing buffer fails.
     pub fn from_exact_iter(iter: impl ExactSizeIterator<Item = T>) -> Result<Self, AllocError> {
-        let capacity = u32::try_from(iter.len()).map_err(|_| AllocError::AllocationFailed)?;
-        let mut o = Self::new(capacity)?;
+        let mut o = Self::new(iter.len())?;
         for i in iter {
             o.push(i);
         }
@@ -56,14 +55,6 @@ impl<A: Allocator, T: core::fmt::Debug> core::fmt::Debug for Vec<T, A> {
 }
 
 impl<T: Clone, A: Allocator + Clone> Vec<T, A> {
-    /// Attempt to clone the vector, returning [`AllocError`] if allocating the
-    /// new backing buffer fails. The clone preserves both length and capacity.
-    ///
-    /// This is panic-safe: if an element's [`Clone`] implementation panics
-    /// part-way through, every element cloned so far is dropped before the
-    /// panic propagates, so nothing is leaked. The guard is the new `Vec`'s own
-    /// [`Drop`] — [`Vec::push`] advances its `len` only *after* each element is
-    /// written, and on unwind `Drop` reclaims exactly that initialized prefix.
     pub fn try_clone(&self) -> Result<Self, AllocError> {
         let mut n: Vec<T, A> = Vec::new_in(self.alloc.clone(), self.inner.capacity)?;
 
@@ -97,7 +88,7 @@ impl<T: Eq, A: Allocator> Eq for Vec<T, A> {}
 
 impl<T: Sized> Vec<T, GlobalAllocator> {
     pub fn from_array<const N: usize>(a: [T; N]) -> Result<Self, AllocError> {
-        let mut v = Vec::new(N as u32)?;
+        let mut v = Vec::new(N)?;
         for i in a {
             v.push(i);
         }
@@ -105,7 +96,7 @@ impl<T: Sized> Vec<T, GlobalAllocator> {
         Ok(v)
     }
 
-    pub fn new(capacity: u32) -> Result<Vec<T>, AllocError> {
+    pub fn new(capacity: usize) -> Result<Vec<T>, AllocError> {
         Vec::new_in(GlobalAllocator, capacity)
     }
 
@@ -121,7 +112,7 @@ impl<T: Sized> Vec<T, GlobalAllocator> {
     /// - Ownership of that allocation is transferred to the returned `Vec`: it
     ///   must not be freed, aliased, or otherwise used elsewhere, since the
     ///   `Vec`'s `Drop` will free it with the same allocator and layout.
-    pub unsafe fn new_from(ptr: *mut T, capacity: u32) -> Vec<T> {
+    pub unsafe fn new_from(ptr: *mut T, capacity: usize) -> Vec<T> {
         Vec {
             // SAFETY: guaranteed by this function's contract; `len == 0` so no
             // element is claimed initialized.
@@ -144,7 +135,7 @@ impl<T: Sized, A: Allocator> Vec<T, A> {
     /// - Ownership of that allocation is transferred to the returned `Vec`: it
     ///   must not be freed, aliased, or otherwise used elsewhere, since the
     ///   `Vec`'s `Drop` will free it with `alloc` and the same layout.
-    pub unsafe fn new_from_with_alloc(ptr: *mut T, capacity: u32, alloc: A) -> Vec<T, A> {
+    pub unsafe fn new_from_with_alloc(ptr: *mut T, capacity: usize, alloc: A) -> Vec<T, A> {
         Vec {
             // SAFETY: guaranteed by this function's contract; `len == 0` so no
             // element is claimed initialized.
@@ -153,15 +144,14 @@ impl<T: Sized, A: Allocator> Vec<T, A> {
         }
     }
 
-    pub fn new_in(alloc: A, capacity: u32) -> Result<Vec<T, A>, AllocError> {
+    pub fn new_in(alloc: A, capacity: usize) -> Result<Vec<T, A>, AllocError> {
         // We don't want to handle ZST
         const {
             assert!(size_of::<T>() != 0);
         }
 
         let ptr = if capacity > 0 {
-            let layout =
-                Layout::array::<T>(capacity as usize).map_err(|_| AllocError::AllocationFailed)?;
+            let layout = Layout::array::<T>(capacity).map_err(|_| AllocError::AllocationFailed)?;
             unsafe { alloc.alloc(layout)? }
         } else {
             core::ptr::null_mut()
@@ -304,7 +294,7 @@ impl<T: Sized, A: Allocator> Vec<T, A> {
 
             core::mem::forget(self);
 
-            let slice_ptr: *mut [T] = core::ptr::slice_from_raw_parts_mut(ptr, cap as usize);
+            let slice_ptr: *mut [T] = core::ptr::slice_from_raw_parts_mut(ptr, cap);
 
             Box::from_raw(alloc, slice_ptr)
         }
@@ -331,7 +321,7 @@ impl<T: Sized, A: Allocator> Drop for Vec<T, A> {
             unsafe {
                 self.alloc.dealloc(
                     self.inner.ptr as *mut u8,
-                    Layout::array::<T>(self.inner.capacity as usize).unwrap(),
+                    Layout::array::<T>(self.inner.capacity).unwrap(),
                 );
             }
         }
@@ -347,8 +337,8 @@ impl<T, A: Allocator> IntoIterator for Vec<T, A> {
 
         // Can't destructure Vec since it's Drop
         let ptr = vec.inner.ptr;
-        let cap = vec.inner.capacity as usize;
-        let len = vec.inner.len as usize;
+        let cap = vec.inner.capacity;
+        let len = vec.inner.len;
 
         // SAFETY: move the allocator out of the `ManuallyDrop` wrapper into the IntoIter
         let alloc = unsafe { core::ptr::read(&vec.alloc) };
@@ -451,7 +441,7 @@ mod kani_proofs {
 
         let vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();
 
-        assert_eq!(vec.capacity(), capacity as usize);
+        assert_eq!(vec.capacity(), capacity);
         assert_eq!(vec.len(), 0);
 
         if capacity == 0 {
@@ -529,15 +519,12 @@ mod kani_proofs {
 
         // Fill to capacity (required by into_boxed_slice)
         let values: [u32; 3] = kani::any();
-        for i in 0..(capacity as usize) {
+        for i in 0..(capacity) {
             vec.push(values[i]);
         }
 
         let len = vec.len();
-        assert_eq!(
-            len, capacity as usize,
-            "Vec must be full for into_boxed_slice"
-        );
+        assert_eq!(len, capacity, "Vec must be full for into_boxed_slice");
 
         let boxed_slice = vec.into_boxed_slice();
 
@@ -798,8 +785,8 @@ mod tests {
 
     #[test]
     fn test_new_from() {
-        let capacity = 3u32;
-        let layout = Layout::array::<i32>(capacity as usize).unwrap();
+        let capacity = 3usize;
+        let layout = Layout::array::<i32>(capacity).unwrap();
         let ptr = unsafe { GlobalAllocator.alloc(layout).unwrap() as *mut i32 };
 
         // SAFETY: `ptr` is a fresh GlobalAllocator allocation for `capacity`
@@ -818,8 +805,8 @@ mod tests {
     fn test_new_from_with_alloc() {
         use crate::test_support::RustSystemAllocator;
 
-        let capacity = 2u32;
-        let layout = Layout::array::<i32>(capacity as usize).unwrap();
+        let capacity = 2usize;
+        let layout = Layout::array::<i32>(capacity).unwrap();
         let ptr = unsafe { RustSystemAllocator.alloc(layout).unwrap() as *mut i32 };
 
         // SAFETY: `ptr` is a fresh RustSystemAllocator allocation for `capacity`
@@ -844,13 +831,13 @@ mod tests {
 
     #[test]
     fn test_assume_init() {
-        let capacity = 3u32;
-        let layout = Layout::array::<i32>(capacity as usize).unwrap();
+        let capacity = 3usize;
+        let layout = Layout::array::<i32>(capacity).unwrap();
         let ptr = unsafe { GlobalAllocator.alloc(layout).unwrap() as *mut i32 };
 
         // Initialize every slot up to capacity before calling assume_init.
         unsafe {
-            for i in 0..capacity as usize {
+            for i in 0..capacity {
                 core::ptr::write(ptr.add(i), (i as i32) * 100);
             }
         }

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -294,6 +294,12 @@ impl<T: Sized, A: Allocator> Vec<T, A> {
 
             core::mem::forget(self);
 
+            let ptr = if cap == 0 {
+                core::ptr::NonNull::<T>::dangling().as_ptr()
+            } else {
+                ptr
+            };
+
             let slice_ptr: *mut [T] = core::ptr::slice_from_raw_parts_mut(ptr, cap);
 
             Box::from_raw(alloc, slice_ptr)
@@ -552,6 +558,20 @@ mod tests {
         let vec: Vec<i32> = Vec::zero();
         assert_eq!(vec.len(), 0);
         assert_eq!(vec.capacity(), 0);
+    }
+
+    #[test]
+    fn test_zero_into_boxed_slice_is_derefable() {
+        // A zero-capacity `Vec` holds a null pointer, which must not reach the
+        // `Box` it converts into: `Box` derefs unconditionally, so a null there
+        // traps under optimization.
+        let b = Vec::<i32>::zero().into_boxed_slice();
+        assert!(b.is_empty());
+        assert_eq!(&*b, &[] as &[i32]);
+        drop(b);
+
+        let b = Vec::<i32>::new(0).unwrap().into_boxed_slice();
+        assert_eq!(&*b, &[] as &[i32]);
     }
 
     #[test]

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -442,7 +442,7 @@ mod kani_proofs {
     #[kani::proof]
     #[kani::unwind(3)]
     fn proof_alloc_dealloc_safety() {
-        let capacity: u32 = kani::any();
+        let capacity: usize = kani::any();
         kani::assume(capacity <= 2);
 
         let vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();
@@ -478,13 +478,13 @@ mod kani_proofs {
     #[kani::proof]
     #[kani::unwind(4)]
     fn proof_vec_clone_correctness() {
-        let capacity: u32 = kani::any();
+        let capacity: usize = kani::any();
         kani::assume(capacity <= 3);
 
         let mut vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();
 
         // Push symbolic values up to capacity
-        let len: u32 = kani::any();
+        let len: usize = kani::any();
         kani::assume(len <= capacity);
 
         for _ in 0..len {
@@ -518,7 +518,7 @@ mod kani_proofs {
     #[kani::proof]
     #[kani::unwind(4)]
     fn proof_vec_into_boxed_slice_correctness() {
-        let capacity: u32 = kani::any();
+        let capacity: usize = kani::any();
         kani::assume(capacity > 0 && capacity <= 3);
 
         let mut vec: Vec<u32, _> = Vec::new_in(RustSystemAllocator, capacity).unwrap();

--- a/tests/util/spectest.rs
+++ b/tests/util/spectest.rs
@@ -302,9 +302,7 @@ impl WasmStream for ByteStream {
                 "wasm module length {} does not fit in u32",
                 vec.len()
             );
-            let inner = unsafe {
-                InnerVec::from_raw_parts(vec.as_mut_ptr(), vec.len() as u32, vec.len() as u32)
-            };
+            let inner = unsafe { InnerVec::from_raw_parts(vec.as_mut_ptr(), vec.len(), vec.len()) };
             Ok(Some(inner))
         } else {
             Ok(None)
@@ -317,7 +315,7 @@ impl WasmStream for ByteStream {
     }
 }
 
-const MAX_CODE_PAGES: u32 = 256;
+const MAX_CODE_PAGES: usize = 256;
 const MAX_CONTROL_FRAMES: usize = 128;
 const MAX_STACK_DEPTH: usize = 256;
 /// Instruction budget for a single invoke/resume, used to catch infinite loops.

--- a/tests/validation_rejections_integration.rs
+++ b/tests/validation_rejections_integration.rs
@@ -85,8 +85,8 @@ impl WasmStream for ByteStream {
         Ok(Some(unsafe {
             InnerVec::from_raw_parts(
                 self.buffer.as_mut_ptr(),
-                self.buffer.len() as u32,
-                self.buffer.len() as u32,
+                self.buffer.len(),
+                self.buffer.len(),
             )
         }))
     }


### PR DESCRIPTION
I originally wrote `Vec<T>` to store `len: u32` and `capacity: u32` because for 64-bit this would fix in two words. This was nasty and not correct and required a lot of `as u32` casts...

We only need to store `len` during the construction of the module/section. I converted stored members to use `Box<[T]>` which is a fat pointer of two words already but cannot increase in length. This does not make in size on 64-bit but decreases size on 32-bit from `12` bytes to `8` bytes.