### PR TITLE
Potential fix for code scanning alert no. 5: Access of invalid pointer

### DIFF
--- a/src/util/box_.rs
+++ b/src/util/box_.rs
@@ -123,6 +123,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// not be used again after this call. Reconstructing a box twice from the
     /// same pointer is undefined behavior (double free).
     pub unsafe fn from_raw(alloc: A, ptr: *mut T) -> Box<T, A> {
+        assert!(!ptr.is_null(), "Box::from_raw received a null pointer");
         Box { ptr, alloc }
     }
 
@@ -161,12 +162,14 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
 impl<T: ?Sized, A: Allocator> Deref for Box<T, A> {
     type Target = T;
     fn deref(&self) -> &T {
+        debug_assert!(!self.ptr.is_null(), "Box internal pointer must be non-null");
         unsafe { &*self.ptr }
     }
 }
 
 impl<T: ?Sized, A: Allocator> DerefMut for Box<T, A> {
     fn deref_mut(&mut self) -> &mut T {
+        debug_assert!(!self.ptr.is_null(), "Box internal pointer must be non-null");
         unsafe { &mut *self.ptr }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/nasa/spacewasm/security/code-scanning/5](https://github.com/nasa/spacewasm/security/code-scanning/5)

To fix this safely without changing intended functionality, enforce the internal invariant that boxed pointers are never null at construction points and assert that invariant before dereferencing. The best single fix in `src/util/box_.rs` is:

1. In `Box::from_raw`, assert `!ptr.is_null()` before constructing `Box`.
2. In `Deref::deref` and `DerefMut::deref_mut`, add `debug_assert!(!self.ptr.is_null())` before unsafe dereference.

This preserves API shape and behavior for valid callers, while turning invalid-pointer misuse into an immediate panic (in `from_raw`) instead of later UB. It also quiets the static warning by making validity checks explicit near sink sites. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
