### PR TITLE
Fix the invalid YAML that stops the welcome workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -69,5 +69,5 @@ jobs:
               repo: context.repo.repo,
               body: `**Welcome**, new contributor!
 
-Please make sure you've read our [contributing guide](https://github.com/nasa/spacewasm/blob/main/CONTRIBUTING.md), as well as our [policy regarding AI usage](https://github.com/nasa/spacewasm/blob/main/AI_POLICY.md), and we look forward to reviewing your pull request shortly`
+            Please make sure you've read our [contributing guide](https://github.com/nasa/spacewasm/blob/main/CONTRIBUTING.md), as well as our [policy regarding AI usage](https://github.com/nasa/spacewasm/blob/main/AI_POLICY.md), and we look forward to reviewing your pull request shortly`
             })


### PR DESCRIPTION
The last line of the comment body in `welcome.yml` lost its indentation in #189. That ends the `script:` block early, and every run of the workflow since it merged has failed:

```
Invalid workflow file: .github/workflows/welcome.yml#L72
You have an error in your yaml syntax on line 72
```

It has gone unnoticed because no first-time contributor has opened a pull request in that window, so no welcome comment was due.

This indents the line to match the `})` below it. The comment still renders without the two leading spaces #189 removed.

*AI use per `AI_POLICY.md`: Claude Code assisted with diagnosing the parse failure, gathering the run history and drafting this description. Scope: one line in `.github/workflows/welcome.yml`, no `src/` change.*
